### PR TITLE
Add user data usage example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,18 @@ use ZxcvbnPhp\Zxcvbn;
 
 $zxcvbn = new Zxcvbn();
 $strength = $zxcvbn->passwordStrength('password');
-echo $strength['score'];
+```
+
+```php
+use ZxcvbnPhp\Zxcvbn;
+
+$userData = array(
+    'Marco' => 1,
+    'marco@gmail.com' => 2,
+);
+
+$zxcvbn = new Zxcvbn();
+$strength = $zxcvbn->passwordStrength('password', $userData);
 ```
 
 ### Acknowledgements


### PR DESCRIPTION
Without documented usage of user data argument, php devs would default to passing the array such as

```
['Marco', 'marco@gmail.com']
```

which fails at dictionary matcher when computing a logarithm of string.
