### PR TITLE
Add php-7.4 and nightly version tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,18 @@
 language: php
 
 php:
+  - 7.4
   - 7.3
   - 7.2
   - 7.1
   - hhvm
+  - nightly
 
 matrix:
   fast_finish: true
   allow_failures:
     - php: hhvm
+    - php: nightly
 
 before_script:
   - composer update --prefer-dist


### PR DESCRIPTION
# Changed log
- Add the `php-7.4` and `php-nightly` tests.
- Let `php-nightly` allow to be failed because nobody can guarantee that unstable PHP version will be successful on every Travis CI build.