### PR TITLE
feat: add feedback warning code to response array

### DIFF
--- a/src/Feedback.php
+++ b/src/Feedback.php
@@ -12,6 +12,22 @@ use ZxcvbnPhp\Matchers\MatchInterface;
  */
 class Feedback
 {
+    const FEEDBACK_CODE_EMPTY = 'empty';
+    const FEEDBACK_CODE_COMMON = 'common';
+    const FEEDBACK_CODE_COMMON_SIMILAR = 'common_similar';
+    const FEEDBACK_CODE_COMMON_TOP_10 = 'common_top_10';
+    const FEEDBACK_CODE_COMMON_TOP_100 = 'common_top_100';
+    const FEEDBACK_CODE_GUESSABLE_DATES = 'guessable_dates';
+    const FEEDBACK_CODE_GUESSABLE_NAME = 'guessable_name';
+    const FEEDBACK_CODE_GUESSABLE_NAMES = 'guessable_names';
+    const FEEDBACK_CODE_GUESSABLE_REPEATED_CHARACTER = 'guessable_repeated_character';
+    const FEEDBACK_CODE_GUESSABLE_REPEATED_STRING = 'guessable_repeated_string';
+    const FEEDBACK_CODE_GUESSABLE_SEQUENCE = 'guessable_sequence';
+    const FEEDBACK_CODE_GUESSABLE_SPATIAL_ROW = 'guessable_spatial_row';
+    const FEEDBACK_CODE_GUESSABLE_SPATIAL_PATTERN = 'guessable_spatial_pattern';
+    const FEEDBACK_CODE_GUESSABLE_WORD = 'guessable_word';
+    const FEEDBACK_CODE_GUESSABLE_YEARS = 'guessable_years';
+
     /**
      * @param int $score
      * @param MatchInterface[] $sequence
@@ -22,6 +38,7 @@ class Feedback
         // starting feedback
         if (count($sequence) === 0) {
             return [
+                'code'        => static::FEEDBACK_CODE_EMPTY,
                 'warning'     => '',
                 'suggestions' => [
                     "Use a few words, avoid common phrases",
@@ -33,6 +50,7 @@ class Feedback
         // no feedback if score is good or great.
         if ($score > 2) {
             return [
+                'code'        => '',
                 'warning'     => '',
                 'suggestions' => [],
             ];

--- a/src/Matchers/Bruteforce.php
+++ b/src/Matchers/Bruteforce.php
@@ -33,6 +33,7 @@ class Bruteforce extends BaseMatch
     public function getFeedback($isSoleMatch)
     {
         return [
+            'code' => "",
             'warning' => "",
             'suggestions' => [
             ]

--- a/src/Matchers/DateMatch.php
+++ b/src/Matchers/DateMatch.php
@@ -2,6 +2,7 @@
 
 namespace ZxcvbnPhp\Matchers;
 
+use ZxcvbnPhp\Feedback;
 use ZxcvbnPhp\Matcher;
 
 class DateMatch extends BaseMatch
@@ -108,6 +109,7 @@ class DateMatch extends BaseMatch
     public function getFeedback($isSoleMatch)
     {
         return [
+            'code' => Feedback::FEEDBACK_CODE_GUESSABLE_DATES,
             'warning' => "Dates are often easy to guess",
             'suggestions' => [
                 'Avoid dates and years that are associated with you'

--- a/src/Matchers/DictionaryMatch.php
+++ b/src/Matchers/DictionaryMatch.php
@@ -2,6 +2,7 @@
 
 namespace ZxcvbnPhp\Matchers;
 
+use ZxcvbnPhp\Feedback;
 use ZxcvbnPhp\Matcher;
 
 class DictionaryMatch extends BaseMatch
@@ -89,8 +90,11 @@ class DictionaryMatch extends BaseMatch
         $startUpper = '/^[A-Z][^A-Z]+$/u';
         $allUpper = '/^[^a-z]+$/u';
 
+        list($code, $warning) = $this->getFeedbackWarning($isSoleMatch);
+
         $feedback = [
-            'warning' => $this->getFeedbackWarning($isSoleMatch),
+            'code' => $code,
+            'warning' => $warning,
             'suggestions' => []
         ];
 
@@ -109,32 +113,53 @@ class DictionaryMatch extends BaseMatch
             case 'passwords':
                 if ($isSoleMatch && !$this->l33t && !$this->reversed) {
                     if ($this->rank <= 10) {
-                        return 'This is a top-10 common password';
+                        return [
+                            Feedback::FEEDBACK_CODE_COMMON_TOP_10,
+                            'This is a top-10 common password',
+                        ];
                     } elseif ($this->rank <= 100) {
-                        return 'This is a top-100 common password';
+                        return [
+                            Feedback::FEEDBACK_CODE_COMMON_TOP_100,
+                            'This is a top-100 common password',
+                        ];
                     } else {
-                        return 'This is a very common password';
+                        return [
+                            Feedback::FEEDBACK_CODE_COMMON,
+                            'This is a very common password'
+                        ];
                     }
                 } elseif ($this->getGuessesLog10() <= 4) {
-                    return 'This is similar to a commonly used password';
+                    return [
+                        Feedback::FEEDBACK_CODE_COMMON_SIMILAR,
+                        'This is similar to a commonly used password',
+                    ];
                 }
                 break;
             case 'english_wikipedia':
                 if ($isSoleMatch) {
-                    return 'A word by itself is easy to guess';
+                    return [
+                        Feedback::FEEDBACK_CODE_GUESSABLE_WORD,
+                        'A word by itself is easy to guess',
+                    ];
                 }
                 break;
             case 'surnames':
             case 'male_names':
             case 'female_names':
                 if ($isSoleMatch) {
-                    return 'Names and surnames by themselves are easy to guess';
+                    return [
+                        Feedback::FEEDBACK_CODE_GUESSABLE_NAME,
+                        'Names and surnames by themselves are easy to guess',
+                    ];
                 } else {
-                    return 'Common names and surnames are easy to guess';
+                    return [
+                        Feedback::FEEDBACK_CODE_GUESSABLE_NAMES,
+                        'Common names and surnames are easy to guess',
+                    ];
                 }
         }
 
-        return '';
+        return ['', ''];
     }
 
     /**

--- a/src/Matchers/RepeatMatch.php
+++ b/src/Matchers/RepeatMatch.php
@@ -2,6 +2,7 @@
 
 namespace ZxcvbnPhp\Matchers;
 
+use ZxcvbnPhp\Feedback;
 use ZxcvbnPhp\Matcher;
 use ZxcvbnPhp\Scorer;
 
@@ -88,7 +89,12 @@ class RepeatMatch extends BaseMatch
             ? 'Repeats like "aaa" are easy to guess'
             : 'Repeats like "abcabcabc" are only slightly harder to guess than "abc"';
 
+        $code = mb_strlen($this->repeatedChar) == 1
+            ? Feedback::FEEDBACK_CODE_GUESSABLE_REPEATED_CHARACTER
+            : Feedback::FEEDBACK_CODE_GUESSABLE_REPEATED_STRING;
+
         return [
+            'code'        => $code,
             'warning'     => $warning,
             'suggestions' => [
                 'Avoid repeated words and characters',

--- a/src/Matchers/SequenceMatch.php
+++ b/src/Matchers/SequenceMatch.php
@@ -2,6 +2,8 @@
 
 namespace ZxcvbnPhp\Matchers;
 
+use ZxcvbnPhp\Feedback;
+
 class SequenceMatch extends BaseMatch
 {
     public const MAX_DELTA = 5;
@@ -87,6 +89,7 @@ class SequenceMatch extends BaseMatch
     public function getFeedback($isSoleMatch)
     {
         return [
+            'code' => Feedback::FEEDBACK_CODE_GUESSABLE_SEQUENCE,
             'warning' => "Sequences like abc or 6543 are easy to guess",
             'suggestions' => [
                 'Avoid sequences'

--- a/src/Matchers/SpatialMatch.php
+++ b/src/Matchers/SpatialMatch.php
@@ -2,6 +2,7 @@
 
 namespace ZxcvbnPhp\Matchers;
 
+use ZxcvbnPhp\Feedback;
 use ZxcvbnPhp\Matcher;
 
 class SpatialMatch extends BaseMatch
@@ -60,7 +61,12 @@ class SpatialMatch extends BaseMatch
             ? 'Straight rows of keys are easy to guess'
             : 'Short keyboard patterns are easy to guess';
 
+        $code = $this->turns == 1
+            ? Feedback::FEEDBACK_CODE_GUESSABLE_SPATIAL_ROW
+            : Feedback::FEEDBACK_CODE_GUESSABLE_SPATIAL_PATTERN;
+
         return [
+            'code' => $code,
             'warning' => $warning,
             'suggestions' => [
                 'Use a longer keyboard pattern with more turns'

--- a/src/Matchers/YearMatch.php
+++ b/src/Matchers/YearMatch.php
@@ -2,6 +2,7 @@
 
 namespace ZxcvbnPhp\Matchers;
 
+use ZxcvbnPhp\Feedback;
 use ZxcvbnPhp\Matcher;
 
 class YearMatch extends BaseMatch
@@ -33,6 +34,7 @@ class YearMatch extends BaseMatch
     public function getFeedback($isSoleMatch)
     {
         return [
+            'code' => Feedback::FEEDBACK_CODE_GUESSABLE_YEARS,
             'warning' => "Recent years are easy to guess",
             'suggestions' => [
                 'Avoid recent years',

--- a/test/FeedbackTest.php
+++ b/test/FeedbackTest.php
@@ -33,6 +33,11 @@ class FeedbackTest extends TestCase
             $feedback['suggestions'],
             "default suggestion #1"
         );
+        $this->assertEquals(
+            'empty',
+            $feedback['code'],
+            "default warning code"
+        );
     }
 
     public function testHighScoringSequence()
@@ -42,6 +47,7 @@ class FeedbackTest extends TestCase
 
         $this->assertEquals('', $feedback['warning'], "no warning for good score");
         $this->assertEmpty($feedback['suggestions'], "no suggestions for good score");
+        $this->assertEquals('', $feedback['code'], "no code for good score");
     }
 
     public function testLongestMatchGetsFeedback()
@@ -69,6 +75,11 @@ class FeedbackTest extends TestCase
             'Avoid sequences',
             $feedback['suggestions'],
             "no suggestion provided for the shorter match"
+        );
+        $this->assertEquals(
+            'guessable_dates',
+            $feedback['code'],
+            "code provided for the longest match"
         );
     }
 

--- a/test/Matchers/DateTest.php
+++ b/test/Matchers/DateTest.php
@@ -2,6 +2,7 @@
 
 namespace ZxcvbnPhp\Test\Matchers;
 
+use ZxcvbnPhp\Feedback;
 use ZxcvbnPhp\Matchers\DateMatch;
 
 class DateTest extends AbstractMatchTest
@@ -310,6 +311,11 @@ class DateTest extends AbstractMatchTest
             'Avoid dates and years that are associated with you',
             $feedback['suggestions'],
             "date match gives correct suggestion"
+        );
+        $this->assertEquals(
+            'guessable_dates',
+            $feedback['code'],
+            "date match gives correct code"
         );
     }
 }

--- a/test/Matchers/DictionaryTest.php
+++ b/test/Matchers/DictionaryTest.php
@@ -267,6 +267,11 @@ class DictionaryTest extends AbstractMatchTest
     {
         $feedback = $this->getFeedbackForToken('password', 'passwords', 2, true);
         $this->assertEquals(
+            'common_top_10',
+            $feedback['code'],
+            'dictionary match returns code for top-10 password'
+        );
+        $this->assertEquals(
             'This is a top-10 common password',
             $feedback['warning'],
             "dictionary match warns about top-10 password"
@@ -276,6 +281,11 @@ class DictionaryTest extends AbstractMatchTest
     public function testFeedbackTop100Password()
     {
         $feedback = $this->getFeedbackForToken('hunter', 'passwords', 37, true);
+        $this->assertEquals(
+            'common_top_100',
+            $feedback['code'],
+            'dictionary match returns code for top-100 password'
+        );
         $this->assertEquals(
             'This is a top-100 common password',
             $feedback['warning'],
@@ -287,6 +297,11 @@ class DictionaryTest extends AbstractMatchTest
     {
         $feedback = $this->getFeedbackForToken('mytruck', 'passwords', 19324, true);
         $this->assertEquals(
+            'common',
+            $feedback['code'],
+            'dictionary match returns code for common password'
+        );
+        $this->assertEquals(
             'This is a very common password',
             $feedback['warning'],
             "dictionary match warns about common password"
@@ -296,6 +311,11 @@ class DictionaryTest extends AbstractMatchTest
     public function testFeedbackTopPasswordNotSoleMatch()
     {
         $feedback = $this->getFeedbackForToken('browndog', 'passwords', 7014, false);
+        $this->assertEquals(
+            'common_similar',
+            $feedback['code'],
+            'dictionary match returns code for common password (not a sole match)'
+        );
         $this->assertEquals(
             'This is similar to a commonly used password',
             $feedback['warning'],
@@ -308,6 +328,11 @@ class DictionaryTest extends AbstractMatchTest
         $feedback = $this->getFeedbackForToken('mytruck', 'passwords', 19324, false);
         $this->assertEquals(
             '',
+            $feedback['code'],
+            'no warning code for a non-sole match in the password dictionary'
+        );
+        $this->assertEquals(
+            '',
             $feedback['warning'],
             "no warning for a non-sole match in the password dictionary"
         );
@@ -316,6 +341,11 @@ class DictionaryTest extends AbstractMatchTest
     public function testFeedbackWikipediaWordSoleMatch()
     {
         $feedback = $this->getFeedbackForToken('university', 'english_wikipedia', 69, true);
+        $this->assertEquals(
+            'guessable_word',
+            $feedback['code'],
+            'dictionary match returns code for Wikipedia word (sole match)'
+        );
         $this->assertEquals(
             'A word by itself is easy to guess',
             $feedback['warning'],
@@ -328,6 +358,11 @@ class DictionaryTest extends AbstractMatchTest
         $feedback = $this->getFeedbackForToken('university', 'english_wikipedia', 69, false);
         $this->assertEquals(
             '',
+            $feedback['code'],
+            'dictionary match doesn\'t rerurn code for Wikipedia word (not a sole match)'
+        );
+        $this->assertEquals(
+            '',
             $feedback['warning'],
             "dictionary match doesn't warn about Wikipedia word (not a sole match)"
         );
@@ -336,6 +371,11 @@ class DictionaryTest extends AbstractMatchTest
     public function testFeedbackNameSoleMatch()
     {
         $feedback = $this->getFeedbackForToken('rodriguez', 'surnames', 21, true);
+        $this->assertEquals(
+            'guessable_name',
+            $feedback['code'],
+            'dictionary match returns code for surname (sole match)'
+        );
         $this->assertEquals(
             'Names and surnames by themselves are easy to guess',
             $feedback['warning'],
@@ -347,6 +387,11 @@ class DictionaryTest extends AbstractMatchTest
     {
         $feedback = $this->getFeedbackForToken('rodriguez', 'surnames', 21, false);
         $this->assertEquals(
+            'guessable_names',
+            $feedback['code'],
+            'dictionary match returns code for surname (not a sole match)'
+        );
+        $this->assertEquals(
             'Common names and surnames are easy to guess',
             $feedback['warning'],
             "dictionary match warns about surname (not a sole match)"
@@ -356,6 +401,11 @@ class DictionaryTest extends AbstractMatchTest
     public function testFeedbackTvAndFilmDictionary()
     {
         $feedback = $this->getFeedbackForToken('know', 'us_tv_and_film', 9, true);
+        $this->assertEquals(
+            '',
+            $feedback['code'],
+            'dictionary match returns code for match from us_tv_and_film dictionary'
+        );
         $this->assertEquals(
             '',
             $feedback['warning'],

--- a/test/Matchers/L33tTest.php
+++ b/test/Matchers/L33tTest.php
@@ -355,6 +355,11 @@ class L33tTest extends AbstractMatchTest
             $feedback['suggestions'],
             "l33t match gives correct suggestion"
         );
+        $this->assertEquals(
+            'guessable_word',
+            $feedback['code'],
+            "l33t match gives correct code"
+        );
     }
 
     public function testFeedbackTop100Password()

--- a/test/Matchers/RepeatTest.php
+++ b/test/Matchers/RepeatTest.php
@@ -291,6 +291,11 @@ class RepeatTest extends AbstractMatchTest
             $feedback['suggestions'],
             "one repeated character gives correct suggestion"
         );
+        $this->assertEquals(
+            'guessable_repeated_character',
+            $feedback['code'],
+            "one repeated character gives correct code"
+        );
     }
 
     public function testFeedbackMultipleCharacterRepeat()
@@ -311,6 +316,11 @@ class RepeatTest extends AbstractMatchTest
             'Avoid repeated words and characters',
             $feedback['suggestions'],
             "multiple repeated characters gives correct suggestion"
+        );
+        $this->assertEquals(
+            'guessable_repeated_string',
+            $feedback['code'],
+            "multiple repeated characters gives correct code"
         );
     }
 }

--- a/test/Matchers/ReverseDictionaryTest.php
+++ b/test/Matchers/ReverseDictionaryTest.php
@@ -60,6 +60,11 @@ class RerverseDictionaryTest extends AbstractMatchTest
             $feedback['suggestions'],
             "reverse dictionary match gives correct suggestion"
         );
+        $this->assertEquals(
+            'guessable_word',
+            $feedback['code'],
+            "reverse dictionary match gives correct code"
+        );
     }
 
     public function testFeedbackTop100Password()
@@ -75,6 +80,11 @@ class RerverseDictionaryTest extends AbstractMatchTest
             'This is similar to a commonly used password',
             $feedback['warning'],
             "reverse dictionary match doesn't give top-100 warning"
+        );
+        $this->assertEquals(
+            'common_similar',
+            $feedback['code'],
+            "reverse dictionary match doesn't give top-100 code"
         );
     }
 
@@ -96,6 +106,11 @@ class RerverseDictionaryTest extends AbstractMatchTest
             'Reversed words aren\'t much harder to guess',
             $feedback['suggestions'],
             "reverse dictionary match doesn't give suggestion for short token"
+        );
+        $this->assertEquals(
+            'guessable_word',
+            $feedback['code'],
+            "reverse dictionary match doesn't give code for short token"
         );
     }
 }

--- a/test/Matchers/SequenceTest.php
+++ b/test/Matchers/SequenceTest.php
@@ -205,5 +205,10 @@ class SequenceTest extends AbstractMatchTest
             $feedback['suggestions'],
             "sequence gives correct suggestion"
         );
+        $this->assertEquals(
+            'guessable_sequence',
+            $feedback['code'],
+            "sequence gives correct code"
+        );
     }
 }

--- a/test/Matchers/YearTest.php
+++ b/test/Matchers/YearTest.php
@@ -153,5 +153,10 @@ class YearTest extends AbstractMatchTest
             $feedback['suggestions'],
             "year match gives correct suggestion #2"
         );
+        $this->assertEquals(
+            'guessable_years',
+            $feedback['code'],
+            "year match gives correct code"
+        );
     }
 }


### PR DESCRIPTION
Actions #54

Adds a 'code' element to the response array in order to allow developers to map the weakness reason in a consistent way to a more suitable message for the specific application and/or localisation requirements.