### PR TITLE
Fix L33tMatch constructor to avoid setting the sub array to null

### DIFF
--- a/src/Matchers/L33tMatch.php
+++ b/src/Matchers/L33tMatch.php
@@ -90,7 +90,7 @@ class L33tMatch extends DictionaryMatch
     {
         parent::__construct($password, $begin, $end, $token, $params);
         if (!empty($params)) {
-            $this->sub = isset($params['sub']) ? $params['sub'] : null;
+            $this->sub = isset($params['sub']) ? $params['sub'] : [];
             $this->subDisplay = isset($params['sub_display']) ? $params['sub_display'] : null;
         }
     }


### PR DESCRIPTION
This should fix a potential PHP warning:

- foreach() argument must be of type array|object, null given in .../vendor/bjeavons/zxcvbn-php/src/Matchers/L33tMatch.php on line 214