### PR TITLE
php 8.1 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
           - '7.3'
           - '7.4'
           - '8.0'
+          - '8.1'
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     steps:
     - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
         "php-coveralls/php-coveralls": "*",
         "squizlabs/php_codesniffer": "3.*"
     },
+    "suggest": {
+        "ext-gmp": "Required for optimized binomial calculations (also requires PHP >= 7.3)"
+    },
     "autoload": {
         "psr-4": { "ZxcvbnPhp\\": "src/" }
     },

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,9 @@
         }
     ],
     "require": {
-        "php": "^7.2 | ^8.0",
-        "symfony/polyfill-mbstring": ">=1.3.1"
+        "php": "^7.2 | ^8.0 | ^8.1",
+        "symfony/polyfill-mbstring": ">=1.3.1",
+        "ext-json": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",

--- a/src/Feedback.php
+++ b/src/Feedback.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp;
 
 use ZxcvbnPhp\Matchers\MatchInterface;

--- a/src/Feedback.php
+++ b/src/Feedback.php
@@ -17,7 +17,7 @@ class Feedback
      * @param MatchInterface[] $sequence
      * @return array
      */
-    public function getFeedback($score, array $sequence)
+    public function getFeedback(int $score, array $sequence): array
     {
         // starting feedback
         if (count($sequence) === 0) {

--- a/src/Matcher.php
+++ b/src/Matcher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp;
 
 use ZxcvbnPhp\Matchers\BaseMatch;

--- a/src/Matcher.php
+++ b/src/Matcher.php
@@ -32,7 +32,7 @@ class Matcher
      *
      * @see  zxcvbn/src/matching.coffee::omnimatch
      */
-    public function getMatches($password, array $userInputs = [])
+    public function getMatches(string $password, array $userInputs = []): array
     {
         $matches = [];
         foreach ($this->getMatchers() as $matcher) {
@@ -48,7 +48,7 @@ class Matcher
         return $matches;
     }
 
-    public function addMatcher(string $className)
+    public function addMatcher(string $className): self
     {
         if (!is_a($className, MatchInterface::class, true)) {
             throw new \InvalidArgumentException(sprintf('Matcher class must implement %s', MatchInterface::class));
@@ -73,7 +73,7 @@ class Matcher
      * @param callable $value_compare_func
      * @return bool
      */
-    public static function usortStable(array &$array, callable $value_compare_func)
+    public static function usortStable(array &$array, callable $value_compare_func): bool
     {
         $index = 0;
         foreach ($array as &$item) {
@@ -89,7 +89,7 @@ class Matcher
         return $result;
     }
 
-    public static function compareMatches(BaseMatch $a, BaseMatch $b)
+    public static function compareMatches(BaseMatch $a, BaseMatch $b): int
     {
         $beginDiff = $a->begin - $b->begin;
         if ($beginDiff) {
@@ -103,7 +103,7 @@ class Matcher
      *
      * @return array Array of classes implementing MatchInterface
      */
-    protected function getMatchers()
+    protected function getMatchers(): array
     {
         return array_merge(
             self::DEFAULT_MATCHERS,

--- a/src/Matchers/BaseMatch.php
+++ b/src/Matchers/BaseMatch.php
@@ -32,13 +32,7 @@ abstract class BaseMatch implements MatchInterface
      */
     public $pattern;
 
-    /**
-     * @param $password
-     * @param $begin
-     * @param $end
-     * @param $token
-     */
-    public function __construct($password, $begin, $end, $token)
+    public function __construct(string $password, int $begin, int $end, string $token)
     {
         $this->password = $password;
         $this->begin = $begin;
@@ -51,10 +45,11 @@ abstract class BaseMatch implements MatchInterface
      *
      * @param  bool $isSoleMatch
      *   Whether this is the only match in the password
-     * @return array
+     * @return array{warning: string, suggestions: array}
      *   Associative array with warning (string) and suggestions (array of strings)
      */
-    abstract public function getFeedback($isSoleMatch);
+    #
+    abstract public function getFeedback(bool $isSoleMatch): array;
 
     /**
      * Find all occurences of regular expression in a string.
@@ -78,7 +73,7 @@ abstract class BaseMatch implements MatchInterface
      *       )
      *     )
      */
-    public static function findAll($string, $regex, $offset = 0)
+    public static function findAll(string $string, string $regex, int $offset = 0): array
     {
         // $offset is the number of multibyte-aware number of characters to offset, but the offset parameter for
         // preg_match_all counts bytes, not characters: to correct this, we need to calculate the byte offset and pass
@@ -126,7 +121,7 @@ abstract class BaseMatch implements MatchInterface
      * @param $k
      * @return int
      */
-    public static function binom($n, $k)
+    public static function binom(int $n, int $k): int
     {
         $j = $res = 1;
 
@@ -144,14 +139,14 @@ abstract class BaseMatch implements MatchInterface
         return $res;
     }
 
-    abstract protected function getRawGuesses();
+    abstract protected function getRawGuesses(): float;
 
-    public function getGuesses()
+    public function getGuesses(): float
     {
         return max($this->getRawGuesses(), $this->getMinimumGuesses());
     }
 
-    protected function getMinimumGuesses()
+    protected function getMinimumGuesses(): int
     {
         if (mb_strlen($this->token) < mb_strlen($this->password)) {
             if (mb_strlen($this->token) === 1) {
@@ -163,7 +158,7 @@ abstract class BaseMatch implements MatchInterface
         return 0;
     }
 
-    public function getGuessesLog10()
+    public function getGuessesLog10(): float
     {
         return log10($this->getGuesses());
     }

--- a/src/Matchers/BaseMatch.php
+++ b/src/Matchers/BaseMatch.php
@@ -48,7 +48,6 @@ abstract class BaseMatch implements MatchInterface
      * @return array{warning: string, suggestions: array}
      *   Associative array with warning (string) and suggestions (array of strings)
      */
-    #
     abstract public function getFeedback(bool $isSoleMatch): array;
 
     /**

--- a/src/Matchers/BaseMatch.php
+++ b/src/Matchers/BaseMatch.php
@@ -139,9 +139,9 @@ abstract class BaseMatch implements MatchInterface
         return $res;
     }
 
-    abstract protected function getRawGuesses(): float;
+    abstract protected function getRawGuesses(): int;
 
-    public function getGuesses(): float
+    public function getGuesses(): int
     {
         return max($this->getRawGuesses(), $this->getMinimumGuesses());
     }

--- a/src/Matchers/BaseMatch.php
+++ b/src/Matchers/BaseMatch.php
@@ -138,14 +138,14 @@ abstract class BaseMatch implements MatchInterface
         return $res;
     }
 
-    abstract protected function getRawGuesses(): int;
+    abstract protected function getRawGuesses(): float;
 
-    public function getGuesses(): int
+    public function getGuesses(): float
     {
         return max($this->getRawGuesses(), $this->getMinimumGuesses());
     }
 
-    protected function getMinimumGuesses(): int
+    protected function getMinimumGuesses(): float
     {
         if (mb_strlen($this->token) < mb_strlen($this->password)) {
             if (mb_strlen($this->token) === 1) {

--- a/src/Matchers/Bruteforce.php
+++ b/src/Matchers/Bruteforce.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Matchers;
 
+use JetBrains\PhpStorm\ArrayShape;
 use ZxcvbnPhp\Scorer;
 
 /**
@@ -30,6 +33,7 @@ class Bruteforce extends BaseMatch
     }
 
 
+    #[ArrayShape(['warning' => 'string', 'suggestions' => 'string[]'])]
     public function getFeedback(bool $isSoleMatch): array
     {
         return [

--- a/src/Matchers/Bruteforce.php
+++ b/src/Matchers/Bruteforce.php
@@ -39,11 +39,12 @@ class Bruteforce extends BaseMatch
         ];
     }
 
-    public function getRawGuesses(): float
+    public function getRawGuesses(): int
     {
         $guesses = pow(self::BRUTEFORCE_CARDINALITY, mb_strlen($this->token));
         if ($guesses === INF) {
-            return defined('PHP_FLOAT_MAX') ? PHP_FLOAT_MAX : 1e308;
+            // use 32bit max int if for some reason PHP_INT_MAX isn't defined
+            return defined('PHP_INT_MAX') ? PHP_INT_MAX : 2147483647;
         }
 
         // small detail: make bruteforce matches at minimum one guess bigger than smallest allowed
@@ -54,6 +55,6 @@ class Bruteforce extends BaseMatch
             $minGuesses = Scorer::MIN_SUBMATCH_GUESSES_MULTI_CHAR + 1;
         }
 
-        return max($guesses, $minGuesses);
+        return (int)max($guesses, $minGuesses);
     }
 }

--- a/src/Matchers/Bruteforce.php
+++ b/src/Matchers/Bruteforce.php
@@ -42,9 +42,8 @@ class Bruteforce extends BaseMatch
     public function getRawGuesses(): int
     {
         $guesses = pow(self::BRUTEFORCE_CARDINALITY, mb_strlen($this->token));
-        if ($guesses === INF) {
-            // use 32bit max int if for some reason PHP_INT_MAX isn't defined
-            return defined('PHP_INT_MAX') ? PHP_INT_MAX : 2147483647;
+        if ($guesses > PHP_INT_MAX) {
+            return PHP_INT_MAX;
         }
 
         // small detail: make bruteforce matches at minimum one guess bigger than smallest allowed

--- a/src/Matchers/Bruteforce.php
+++ b/src/Matchers/Bruteforce.php
@@ -22,7 +22,7 @@ class Bruteforce extends BaseMatch
      * @param array $userInputs
      * @return Bruteforce[]
      */
-    public static function match($password, array $userInputs = [])
+    public static function match(string $password, array $userInputs = []): array
     {
         // Matches entire string.
         $match = new static($password, 0, mb_strlen($password) - 1, $password);
@@ -30,7 +30,7 @@ class Bruteforce extends BaseMatch
     }
 
 
-    public function getFeedback($isSoleMatch)
+    public function getFeedback(bool $isSoleMatch): array
     {
         return [
             'warning' => "",
@@ -39,7 +39,7 @@ class Bruteforce extends BaseMatch
         ];
     }
 
-    public function getRawGuesses()
+    public function getRawGuesses(): float
     {
         $guesses = pow(self::BRUTEFORCE_CARDINALITY, mb_strlen($this->token));
         if ($guesses === INF) {

--- a/src/Matchers/Bruteforce.php
+++ b/src/Matchers/Bruteforce.php
@@ -39,11 +39,11 @@ class Bruteforce extends BaseMatch
         ];
     }
 
-    public function getRawGuesses(): int
+    public function getRawGuesses(): float
     {
         $guesses = pow(self::BRUTEFORCE_CARDINALITY, mb_strlen($this->token));
-        if ($guesses > PHP_INT_MAX) {
-            return PHP_INT_MAX;
+        if ($guesses === INF) {
+            return PHP_FLOAT_MAX;
         }
 
         // small detail: make bruteforce matches at minimum one guess bigger than smallest allowed
@@ -54,6 +54,6 @@ class Bruteforce extends BaseMatch
             $minGuesses = Scorer::MIN_SUBMATCH_GUESSES_MULTI_CHAR + 1;
         }
 
-        return (int)max($guesses, $minGuesses);
+        return max($guesses, $minGuesses);
     }
 }

--- a/src/Matchers/DateMatch.php
+++ b/src/Matchers/DateMatch.php
@@ -73,7 +73,7 @@ class DateMatch extends BaseMatch
      * @param array $userInputs
      * @return DateMatch[]
      */
-    public static function match($password, array $userInputs = [])
+    public static function match(string $password, array $userInputs = []): array
     {
         # a "date" is recognized as:
         #   any 3-tuple that starts or ends with a 2- or 4-digit year,
@@ -105,7 +105,7 @@ class DateMatch extends BaseMatch
         return $matches;
     }
 
-    public function getFeedback($isSoleMatch)
+    public function getFeedback(bool $isSoleMatch): array
     {
         return [
             'warning' => "Dates are often easy to guess",
@@ -122,7 +122,7 @@ class DateMatch extends BaseMatch
      * @param string $token
      * @param array $params An array with keys: [day, month, year, separator].
      */
-    public function __construct($password, $begin, $end, $token, array $params)
+    public function __construct(string $password, int $begin, int $end, string $token, array $params)
     {
         parent::__construct($password, $begin, $end, $token);
         $this->day = $params['day'];
@@ -138,7 +138,7 @@ class DateMatch extends BaseMatch
      *
      * @return array
      */
-    protected static function datesWithSeparators($password)
+    protected static function datesWithSeparators(string $password): array
     {
         $matches = [];
         $length = mb_strlen($password);
@@ -184,7 +184,7 @@ class DateMatch extends BaseMatch
      *
      * @return array
      */
-    protected static function datesWithoutSeparators($password)
+    protected static function datesWithoutSeparators(string $password): array
     {
         $matches = [];
         $length = mb_strlen($password);
@@ -256,12 +256,12 @@ class DateMatch extends BaseMatch
      * @param array $candidate
      * @return int Returns the number of years between the detected year and the current year for a candidate.
      */
-    protected static function getDistanceForMatchCandidate($candidate)
+    protected static function getDistanceForMatchCandidate(array $candidate): int
     {
         return abs((int)$candidate['year'] - static::getReferenceYear());
     }
 
-    public static function getReferenceYear()
+    public static function getReferenceYear(): int
     {
         return (int)date('Y');
     }
@@ -271,7 +271,7 @@ class DateMatch extends BaseMatch
      * @return array|bool Returns an associative array containing 'day', 'month' and 'year' keys, or false if the
      *                    provided date array is invalid.
      */
-    protected static function checkDate($ints)
+    protected static function checkDate(array $ints)
     {
         # given a 3-tuple, discard if:
         #   middle int is over 31 (for all dmy formats, years are never allowed in the middle)
@@ -347,7 +347,7 @@ class DateMatch extends BaseMatch
      * @return array|bool Returns an associative array containing 'day' and 'month' keys, or false if any combination
      *                    of the two numbers does not match a day and month.
      */
-    protected static function mapIntsToDayMonth($ints)
+    protected static function mapIntsToDayMonth(array $ints)
     {
         foreach ([$ints, array_reverse($ints)] as list($d, $m)) {
             if ($d >= 1 && $d <= 31 && $m >= 1 && $m <= 12) {
@@ -365,7 +365,7 @@ class DateMatch extends BaseMatch
      * @param int $year A two digit number representing a year.
      * @return int Returns the most likely four digit year for the provided number.
      */
-    protected static function twoToFourDigitYear($year)
+    protected static function twoToFourDigitYear(int $year): int
     {
         if ($year > 99) {
             return $year;
@@ -392,7 +392,7 @@ class DateMatch extends BaseMatch
      * @param array $matches An array of matches (not Match objects)
      * @return array The provided array of matches, but with matches that are strict substrings of others removed.
      */
-    protected static function removeRedundantMatches($matches)
+    protected static function removeRedundantMatches(array $matches): array
     {
         return array_filter($matches, function ($match) use ($matches) {
             foreach ($matches as $otherMatch) {
@@ -408,7 +408,7 @@ class DateMatch extends BaseMatch
         });
     }
 
-    protected function getRawGuesses()
+    protected function getRawGuesses(): float
     {
         // base guesses: (year distance from REFERENCE_YEAR) * num_days * num_years
         $yearSpace = max(abs($this->year - static::getReferenceYear()), static::MIN_YEAR_SPACE);

--- a/src/Matchers/DateMatch.php
+++ b/src/Matchers/DateMatch.php
@@ -408,7 +408,7 @@ class DateMatch extends BaseMatch
         });
     }
 
-    protected function getRawGuesses(): int
+    protected function getRawGuesses(): float
     {
         // base guesses: (year distance from REFERENCE_YEAR) * num_days * num_years
         $yearSpace = max(abs($this->year - static::getReferenceYear()), static::MIN_YEAR_SPACE);

--- a/src/Matchers/DateMatch.php
+++ b/src/Matchers/DateMatch.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Matchers;
 
+use JetBrains\PhpStorm\ArrayShape;
 use ZxcvbnPhp\Matcher;
 
 class DateMatch extends BaseMatch
@@ -105,6 +108,7 @@ class DateMatch extends BaseMatch
         return $matches;
     }
 
+    #[ArrayShape(['warning' => 'string', 'suggestions' => 'string[]'])]
     public function getFeedback(bool $isSoleMatch): array
     {
         return [
@@ -202,9 +206,9 @@ class DateMatch extends BaseMatch
 
                 $possibleSplits = static::$DATE_SPLITS[mb_strlen($token)];
                 foreach ($possibleSplits as $splitPositions) {
-                    $day = mb_substr($token, 0, $splitPositions[0]);
-                    $month = mb_substr($token, $splitPositions[0], $splitPositions[1] - $splitPositions[0]);
-                    $year = mb_substr($token, $splitPositions[1]);
+                    $day = (int)mb_substr($token, 0, $splitPositions[0]);
+                    $month = (int)mb_substr($token, $splitPositions[0], $splitPositions[1] - $splitPositions[0]);
+                    $year = (int)mb_substr($token, $splitPositions[1]);
 
                     $date = static::checkDate([$day, $month, $year]);
                     if ($date !== false) {
@@ -285,7 +289,7 @@ class DateMatch extends BaseMatch
             return false;
         }
 
-        $invalidYear = count(array_filter($ints, function (int $int) {
+        $invalidYear = count(array_filter($ints, function (int $int): bool {
             return ($int >= 100 && $int < static::MIN_YEAR)
                 || ($int > static::MAX_YEAR);
         }));
@@ -293,13 +297,13 @@ class DateMatch extends BaseMatch
             return false;
         }
 
-        $over12 = count(array_filter($ints, function (int $int) {
+        $over12 = count(array_filter($ints, function (int $int): bool {
             return $int > 12;
         }));
-        $over31 = count(array_filter($ints, function (int $int) {
+        $over31 = count(array_filter($ints, function (int $int): bool {
             return $int > 31;
         }));
-        $under1 = count(array_filter($ints, function (int $int) {
+        $under1 = count(array_filter($ints, function (int $int): bool {
             return $int <= 0;
         }));
 
@@ -313,7 +317,7 @@ class DateMatch extends BaseMatch
             [$ints[0], [$ints[1], $ints[2]]], // year first
         ];
 
-        foreach ($possibleYearSplits as list($year, $rest)) {
+        foreach ($possibleYearSplits as [$year, $rest]) {
             if ($year >= static::MIN_YEAR && $year <= static::MAX_YEAR) {
                 if ($dm = static::mapIntsToDayMonth($rest)) {
                     return [
@@ -329,7 +333,7 @@ class DateMatch extends BaseMatch
             }
         }
 
-        foreach ($possibleYearSplits as list($year, $rest)) {
+        foreach ($possibleYearSplits as [$year, $rest]) {
             if ($dm = static::mapIntsToDayMonth($rest)) {
                 return [
                     'year'  => static::twoToFourDigitYear($year),
@@ -349,7 +353,7 @@ class DateMatch extends BaseMatch
      */
     protected static function mapIntsToDayMonth(array $ints)
     {
-        foreach ([$ints, array_reverse($ints)] as list($d, $m)) {
+        foreach ([$ints, array_reverse($ints)] as [$d, $m]) {
             if ($d >= 1 && $d <= 31 && $m >= 1 && $m <= 12) {
                 return [
                     'day'   => $d,

--- a/src/Matchers/DateMatch.php
+++ b/src/Matchers/DateMatch.php
@@ -285,7 +285,7 @@ class DateMatch extends BaseMatch
             return false;
         }
 
-        $invalidYear = count(array_filter($ints, function ($int) {
+        $invalidYear = count(array_filter($ints, function (int $int) {
             return ($int >= 100 && $int < static::MIN_YEAR)
                 || ($int > static::MAX_YEAR);
         }));
@@ -293,13 +293,13 @@ class DateMatch extends BaseMatch
             return false;
         }
 
-        $over12 = count(array_filter($ints, function ($int) {
+        $over12 = count(array_filter($ints, function (int $int) {
             return $int > 12;
         }));
-        $over31 = count(array_filter($ints, function ($int) {
+        $over31 = count(array_filter($ints, function (int $int) {
             return $int > 31;
         }));
-        $under1 = count(array_filter($ints, function ($int) {
+        $under1 = count(array_filter($ints, function (int $int) {
             return $int <= 0;
         }));
 
@@ -394,7 +394,7 @@ class DateMatch extends BaseMatch
      */
     protected static function removeRedundantMatches(array $matches): array
     {
-        return array_filter($matches, function ($match) use ($matches) {
+        return array_filter($matches, function (array $match) use ($matches): bool {
             foreach ($matches as $otherMatch) {
                 if ($match === $otherMatch) {
                     continue;

--- a/src/Matchers/DateMatch.php
+++ b/src/Matchers/DateMatch.php
@@ -408,7 +408,7 @@ class DateMatch extends BaseMatch
         });
     }
 
-    protected function getRawGuesses(): float
+    protected function getRawGuesses(): int
     {
         // base guesses: (year distance from REFERENCE_YEAR) * num_days * num_years
         $yearSpace = max(abs($this->year - static::getReferenceYear()), static::MIN_YEAR_SPACE);

--- a/src/Matchers/DictionaryMatch.php
+++ b/src/Matchers/DictionaryMatch.php
@@ -191,7 +191,7 @@ class DictionaryMatch extends BaseMatch
         return self::$rankedDictionaries;
     }
 
-    protected function getRawGuesses(): int
+    protected function getRawGuesses(): float
     {
         $guesses = $this->rank;
         $guesses *= $this->getUppercaseVariations();
@@ -199,7 +199,7 @@ class DictionaryMatch extends BaseMatch
         return $guesses;
     }
 
-    protected function getUppercaseVariations(): int
+    protected function getUppercaseVariations(): float
     {
         $word = $this->token;
         if (preg_match(self::ALL_LOWER, $word) || mb_strtolower($word) === $word) {

--- a/src/Matchers/DictionaryMatch.php
+++ b/src/Matchers/DictionaryMatch.php
@@ -224,8 +224,8 @@ class DictionaryMatch extends BaseMatch
         // otherwise calculate the number of ways to capitalize U+L uppercase+lowercase letters
         // with U uppercase letters or less. or, if there's more uppercase than lower (for eg. PASSwORD),
         // the number of ways to lowercase U+L letters with L lowercase letters or less.
-        $uppercase = count(array_filter(preg_split('//u', $word, null, PREG_SPLIT_NO_EMPTY), 'ctype_upper'));
-        $lowercase = count(array_filter(preg_split('//u', $word, null, PREG_SPLIT_NO_EMPTY), 'ctype_lower'));
+        $uppercase = count(array_filter(preg_split('//u', $word, -1, PREG_SPLIT_NO_EMPTY), 'ctype_upper'));
+        $lowercase = count(array_filter(preg_split('//u', $word, -1, PREG_SPLIT_NO_EMPTY), 'ctype_lower'));
 
         $variations = 0;
         for ($i = 1; $i <= min($uppercase, $lowercase); $i++) {

--- a/src/Matchers/DictionaryMatch.php
+++ b/src/Matchers/DictionaryMatch.php
@@ -40,7 +40,7 @@ class DictionaryMatch extends BaseMatch
      * @param array $rankedDictionaries
      * @return DictionaryMatch[]
      */
-    public static function match($password, array $userInputs = [], $rankedDictionaries = [])
+    public static function match(string $password, array $userInputs = [], array $rankedDictionaries = []): array
     {
         $matches = [];
         if ($rankedDictionaries) {
@@ -74,7 +74,7 @@ class DictionaryMatch extends BaseMatch
      * @param string $token
      * @param array $params An array with keys: [dictionary_name, matched_word, rank].
      */
-    public function __construct($password, $begin, $end, $token, array $params = [])
+    public function __construct(string $password, int $begin, int $end, string $token, array $params = [])
     {
         parent::__construct($password, $begin, $end, $token);
         if (!empty($params)) {
@@ -84,7 +84,7 @@ class DictionaryMatch extends BaseMatch
         }
     }
 
-    public function getFeedback($isSoleMatch)
+    public function getFeedback(bool $isSoleMatch): array
     {
         $startUpper = '/^[A-Z][^A-Z]+$/u';
         $allUpper = '/^[^a-z]+$/u';
@@ -103,7 +103,7 @@ class DictionaryMatch extends BaseMatch
         return $feedback;
     }
 
-    public function getFeedbackWarning($isSoleMatch)
+    public function getFeedbackWarning(bool $isSoleMatch): string
     {
         switch ($this->dictionaryName) {
             case 'passwords':
@@ -144,7 +144,7 @@ class DictionaryMatch extends BaseMatch
      * @param array $dict
      * @return array
      */
-    protected static function dictionaryMatch($password, $dict)
+    protected static function dictionaryMatch(string $password, array $dict): array
     {
         $result = [];
         $length = mb_strlen($password);
@@ -175,7 +175,7 @@ class DictionaryMatch extends BaseMatch
      *
      * @return array
      */
-    protected static function getRankedDictionaries()
+    protected static function getRankedDictionaries(): array
     {
         if (empty(self::$rankedDictionaries)) {
             $json = file_get_contents(dirname(__FILE__) . '/frequency_lists.json');
@@ -194,7 +194,7 @@ class DictionaryMatch extends BaseMatch
     /**
      * @return integer
      */
-    protected function getRawGuesses()
+    protected function getRawGuesses(): float
     {
         $guesses = $this->rank;
         $guesses *= $this->getUppercaseVariations();
@@ -205,7 +205,7 @@ class DictionaryMatch extends BaseMatch
     /**
      * @return integer
      */
-    protected function getUppercaseVariations()
+    protected function getUppercaseVariations(): int
     {
         $word = $this->token;
         if (preg_match(self::ALL_LOWER, $word) || mb_strtolower($word) === $word) {

--- a/src/Matchers/DictionaryMatch.php
+++ b/src/Matchers/DictionaryMatch.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Matchers;
 
+use JetBrains\PhpStorm\ArrayShape;
 use ZxcvbnPhp\Matcher;
 
 class DictionaryMatch extends BaseMatch
@@ -33,7 +36,7 @@ class DictionaryMatch extends BaseMatch
     protected const ALL_LOWER = "/^[^A-Z]+$/u";
 
     /**
-     * Match occurences of dictionary words in password.
+     * Match occurrences of dictionary words in password.
      *
      * @param string $password
      * @param array $userInputs
@@ -84,6 +87,11 @@ class DictionaryMatch extends BaseMatch
         }
     }
 
+    /**
+     * @param bool $isSoleMatch
+     * @return array
+     */
+    #[ArrayShape(['warning' => 'string', 'suggestions' => 'string[]'])]
     public function getFeedback(bool $isSoleMatch): array
     {
         $startUpper = '/^[A-Z][^A-Z]+$/u';

--- a/src/Matchers/DictionaryMatch.php
+++ b/src/Matchers/DictionaryMatch.php
@@ -78,9 +78,9 @@ class DictionaryMatch extends BaseMatch
     {
         parent::__construct($password, $begin, $end, $token);
         if (!empty($params)) {
-            $this->dictionaryName = isset($params['dictionary_name']) ? $params['dictionary_name'] : null;
-            $this->matchedWord = isset($params['matched_word']) ? $params['matched_word'] : null;
-            $this->rank = isset($params['rank']) ? $params['rank'] : null;
+            $this->dictionaryName = $params['dictionary_name'] ?? null;
+            $this->matchedWord = $params['matched_word'] ?? null;
+            $this->rank = $params['rank'] ?? null;
         }
     }
 

--- a/src/Matchers/DictionaryMatch.php
+++ b/src/Matchers/DictionaryMatch.php
@@ -78,9 +78,9 @@ class DictionaryMatch extends BaseMatch
     {
         parent::__construct($password, $begin, $end, $token);
         if (!empty($params)) {
-            $this->dictionaryName = $params['dictionary_name'] ?? null;
-            $this->matchedWord = $params['matched_word'] ?? null;
-            $this->rank = $params['rank'] ?? null;
+            $this->dictionaryName = $params['dictionary_name'] ?? '';
+            $this->matchedWord = $params['matched_word'] ?? '';
+            $this->rank = $params['rank'] ?? 0;
         }
     }
 

--- a/src/Matchers/DictionaryMatch.php
+++ b/src/Matchers/DictionaryMatch.php
@@ -199,9 +199,6 @@ class DictionaryMatch extends BaseMatch
         return $guesses;
     }
 
-    /**
-     * @return integer
-     */
     protected function getUppercaseVariations(): int
     {
         $word = $this->token;

--- a/src/Matchers/DictionaryMatch.php
+++ b/src/Matchers/DictionaryMatch.php
@@ -191,10 +191,7 @@ class DictionaryMatch extends BaseMatch
         return self::$rankedDictionaries;
     }
 
-    /**
-     * @return integer
-     */
-    protected function getRawGuesses(): float
+    protected function getRawGuesses(): int
     {
         $guesses = $this->rank;
         $guesses *= $this->getUppercaseVariations();

--- a/src/Matchers/L33tMatch.php
+++ b/src/Matchers/L33tMatch.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Matchers;
 
+use JetBrains\PhpStorm\ArrayShape;
 use ZxcvbnPhp\Matcher;
 
 /**
@@ -95,6 +98,7 @@ class L33tMatch extends DictionaryMatch
         }
     }
 
+    #[ArrayShape(['warning' => 'string', 'suggestions' => 'string[]'])]
     public function getFeedback(bool $isSoleMatch): array
     {
         $feedback = parent::getFeedback($isSoleMatch);

--- a/src/Matchers/L33tMatch.php
+++ b/src/Matchers/L33tMatch.php
@@ -28,7 +28,7 @@ class L33tMatch extends DictionaryMatch
      * @param array $rankedDictionaries
      * @return L33tMatch[]
      */
-    public static function match($password, array $userInputs = [], $rankedDictionaries = [])
+    public static function match(string $password, array $userInputs = [], array $rankedDictionaries = []): array
     {
         // Translate l33t password and dictionary match the translated password.
         $maps = array_filter(static::getL33tSubstitutions(static::getL33tSubtable($password)));
@@ -86,7 +86,7 @@ class L33tMatch extends DictionaryMatch
      * @param string $token
      * @param array $params An array with keys: [sub, sub_display].
      */
-    public function __construct($password, $begin, $end, $token, $params = [])
+    public function __construct(string $password, int $begin, int $end, string $token, array $params = [])
     {
         parent::__construct($password, $begin, $end, $token, $params);
         if (!empty($params)) {
@@ -95,7 +95,7 @@ class L33tMatch extends DictionaryMatch
         }
     }
 
-    public function getFeedback($isSoleMatch)
+    public function getFeedback(bool $isSoleMatch): array
     {
         $feedback = parent::getFeedback($isSoleMatch);
 
@@ -109,12 +109,12 @@ class L33tMatch extends DictionaryMatch
      * @param array  $map
      * @return string
      */
-    protected static function translate($string, $map)
+    protected static function translate(string $string, array $map): string
     {
         return str_replace(array_keys($map), array_values($map), $string);
     }
 
-    protected static function getL33tTable()
+    protected static function getL33tTable(): array
     {
         return [
             'a' => ['4', '@'],
@@ -132,7 +132,7 @@ class L33tMatch extends DictionaryMatch
         ];
     }
 
-    protected static function getL33tSubtable($password)
+    protected static function getL33tSubtable(string $password): array
     {
         // The preg_split call below is a multibyte compatible version of str_split
         $passwordChars = array_unique(preg_split('//u', $password, null, PREG_SPLIT_NO_EMPTY));
@@ -151,7 +151,7 @@ class L33tMatch extends DictionaryMatch
         return $subTable;
     }
 
-    protected static function getL33tSubstitutions($subtable)
+    protected static function getL33tSubstitutions(array $subtable): array
     {
         $keys = array_keys($subtable);
         $substitutions = self::substitutionTableHelper($subtable, $keys, [[]]);
@@ -164,7 +164,7 @@ class L33tMatch extends DictionaryMatch
         return $substitutions;
     }
 
-    protected static function substitutionTableHelper($table, $keys, $subs)
+    protected static function substitutionTableHelper(array $table, array $keys, array $subs): array
     {
         if (empty($keys)) {
             return $subs;
@@ -202,12 +202,12 @@ class L33tMatch extends DictionaryMatch
         return self::substitutionTableHelper($table, $otherKeys, $nextSubs);
     }
 
-    protected function getRawGuesses()
+    protected function getRawGuesses(): float
     {
         return parent::getRawGuesses() * $this->getL33tVariations();
     }
 
-    protected function getL33tVariations()
+    protected function getL33tVariations(): int
     {
         $variations = 1;
 

--- a/src/Matchers/L33tMatch.php
+++ b/src/Matchers/L33tMatch.php
@@ -90,7 +90,7 @@ class L33tMatch extends DictionaryMatch
     {
         parent::__construct($password, $begin, $end, $token, $params);
         if (!empty($params)) {
-            $this->sub = $params['sub'] ?? null;
+            $this->sub = $params['sub'] ?? [];
             $this->subDisplay = $params['sub_display'] ?? null;
         }
     }

--- a/src/Matchers/L33tMatch.php
+++ b/src/Matchers/L33tMatch.php
@@ -135,7 +135,7 @@ class L33tMatch extends DictionaryMatch
     protected static function getL33tSubtable(string $password): array
     {
         // The preg_split call below is a multibyte compatible version of str_split
-        $passwordChars = array_unique(preg_split('//u', $password, null, PREG_SPLIT_NO_EMPTY));
+        $passwordChars = array_unique(preg_split('//u', $password, -1, PREG_SPLIT_NO_EMPTY));
 
         $subTable = [];
 
@@ -212,7 +212,7 @@ class L33tMatch extends DictionaryMatch
         $variations = 1;
 
         foreach ($this->sub as $substitution => $letter) {
-            $characters = preg_split('//u', mb_strtolower($this->token), null, PREG_SPLIT_NO_EMPTY);
+            $characters = preg_split('//u', mb_strtolower($this->token), -1, PREG_SPLIT_NO_EMPTY);
 
             $subbed = count(array_filter($characters, function ($character) use ($substitution) {
                 return (string)$character === (string)$substitution;

--- a/src/Matchers/L33tMatch.php
+++ b/src/Matchers/L33tMatch.php
@@ -202,12 +202,12 @@ class L33tMatch extends DictionaryMatch
         return self::substitutionTableHelper($table, $otherKeys, $nextSubs);
     }
 
-    protected function getRawGuesses(): int
+    protected function getRawGuesses(): float
     {
         return parent::getRawGuesses() * $this->getL33tVariations();
     }
 
-    protected function getL33tVariations(): int
+    protected function getL33tVariations(): float
     {
         $variations = 1;
 

--- a/src/Matchers/L33tMatch.php
+++ b/src/Matchers/L33tMatch.php
@@ -157,7 +157,7 @@ class L33tMatch extends DictionaryMatch
         $substitutions = self::substitutionTableHelper($subtable, $keys, [[]]);
 
         // Converts the substitution arrays from [ [a, b], [c, d] ] to [ a => b, c => d ]
-        $substitutions = array_map(function ($subArray) {
+        $substitutions = array_map(function (array $subArray): array {
             return array_combine(array_column($subArray, 0), array_column($subArray, 1));
         }, $substitutions);
 

--- a/src/Matchers/L33tMatch.php
+++ b/src/Matchers/L33tMatch.php
@@ -90,8 +90,8 @@ class L33tMatch extends DictionaryMatch
     {
         parent::__construct($password, $begin, $end, $token, $params);
         if (!empty($params)) {
-            $this->sub = isset($params['sub']) ? $params['sub'] : null;
-            $this->subDisplay = isset($params['sub_display']) ? $params['sub_display'] : null;
+            $this->sub = $params['sub'] ?? null;
+            $this->subDisplay = $params['sub_display'] ?? null;
         }
     }
 

--- a/src/Matchers/L33tMatch.php
+++ b/src/Matchers/L33tMatch.php
@@ -202,7 +202,7 @@ class L33tMatch extends DictionaryMatch
         return self::substitutionTableHelper($table, $otherKeys, $nextSubs);
     }
 
-    protected function getRawGuesses(): float
+    protected function getRawGuesses(): int
     {
         return parent::getRawGuesses() * $this->getL33tVariations();
     }

--- a/src/Matchers/MatchInterface.php
+++ b/src/Matchers/MatchInterface.php
@@ -16,7 +16,7 @@ interface MatchInterface
      */
     public static function match(string $password, array $userInputs = []): array;
 
-    public function getGuesses(): int;
+    public function getGuesses(): float;
 
     public function getGuessesLog10(): float;
 }

--- a/src/Matchers/MatchInterface.php
+++ b/src/Matchers/MatchInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Matchers;
 
 interface MatchInterface

--- a/src/Matchers/MatchInterface.php
+++ b/src/Matchers/MatchInterface.php
@@ -12,17 +12,17 @@ interface MatchInterface
      * @code array('Alice Smith')
      * @endcode
      *
-     * @return array Array of Match objects
+     * @return array|BaseMatch[] Array of Match objects
      */
-    public static function match($password, array $userInputs = []);
+    public static function match(string $password, array $userInputs = []): array;
 
     /**
      * @return integer
      */
-    public function getGuesses();
+    public function getGuesses(): float;
 
     /**
      * @return float
      */
-    public function getGuessesLog10();
+    public function getGuessesLog10(): float;
 }

--- a/src/Matchers/MatchInterface.php
+++ b/src/Matchers/MatchInterface.php
@@ -16,13 +16,7 @@ interface MatchInterface
      */
     public static function match(string $password, array $userInputs = []): array;
 
-    /**
-     * @return integer
-     */
-    public function getGuesses(): float;
+    public function getGuesses(): int;
 
-    /**
-     * @return float
-     */
     public function getGuessesLog10(): float;
 }

--- a/src/Matchers/RepeatMatch.php
+++ b/src/Matchers/RepeatMatch.php
@@ -114,7 +114,7 @@ class RepeatMatch extends BaseMatch
         }
     }
 
-    protected function getRawGuesses(): float
+    protected function getRawGuesses(): int
     {
         return $this->baseGuesses * $this->repeatCount;
     }

--- a/src/Matchers/RepeatMatch.php
+++ b/src/Matchers/RepeatMatch.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Matchers;
 
+use JetBrains\PhpStorm\ArrayShape;
 use ZxcvbnPhp\Matcher;
 use ZxcvbnPhp\Scorer;
 
@@ -28,7 +31,7 @@ class RepeatMatch extends BaseMatch
     /**
      * Match 3 or more repeated characters.
      *
-     * @param $password
+     * @param string $password
      * @param array $userInputs
      * @return RepeatMatch[]
      */
@@ -82,6 +85,7 @@ class RepeatMatch extends BaseMatch
         return $matches;
     }
 
+    #[ArrayShape(['warning' => 'string', 'suggestions' => 'string[]'])]
     public function getFeedback(bool $isSoleMatch): array
     {
         $warning = mb_strlen($this->repeatedChar) == 1

--- a/src/Matchers/RepeatMatch.php
+++ b/src/Matchers/RepeatMatch.php
@@ -32,7 +32,7 @@ class RepeatMatch extends BaseMatch
      * @param array $userInputs
      * @return RepeatMatch[]
      */
-    public static function match($password, array $userInputs = [])
+    public static function match(string $password, array $userInputs = []): array
     {
         $matches = [];
         $lastIndex = 0;
@@ -82,7 +82,7 @@ class RepeatMatch extends BaseMatch
         return $matches;
     }
 
-    public function getFeedback($isSoleMatch)
+    public function getFeedback(bool $isSoleMatch): array
     {
         $warning = mb_strlen($this->repeatedChar) == 1
             ? 'Repeats like "aaa" are easy to guess'
@@ -103,7 +103,7 @@ class RepeatMatch extends BaseMatch
      * @param string $token
      * @param array $params An array with keys: [repeated_char, base_guesses, base_matches, repeat_count].
      */
-    public function __construct($password, $begin, $end, $token, $params = [])
+    public function __construct(string $password, int $begin, int $end, string $token, array $params = [])
     {
         parent::__construct($password, $begin, $end, $token);
         if (!empty($params)) {
@@ -114,7 +114,7 @@ class RepeatMatch extends BaseMatch
         }
     }
 
-    protected function getRawGuesses()
+    protected function getRawGuesses(): float
     {
         return $this->baseGuesses * $this->repeatCount;
     }

--- a/src/Matchers/RepeatMatch.php
+++ b/src/Matchers/RepeatMatch.php
@@ -114,7 +114,7 @@ class RepeatMatch extends BaseMatch
         }
     }
 
-    protected function getRawGuesses(): int
+    protected function getRawGuesses(): float
     {
         return $this->baseGuesses * $this->repeatCount;
     }

--- a/src/Matchers/RepeatMatch.php
+++ b/src/Matchers/RepeatMatch.php
@@ -107,10 +107,10 @@ class RepeatMatch extends BaseMatch
     {
         parent::__construct($password, $begin, $end, $token);
         if (!empty($params)) {
-            $this->repeatedChar = isset($params['repeated_char']) ? $params['repeated_char'] : null;
-            $this->baseGuesses = isset($params['base_guesses']) ? $params['base_guesses'] : null;
-            $this->baseMatches = isset($params['base_matches']) ? $params['base_matches'] : null;
-            $this->repeatCount = isset($params['repeat_count']) ? $params['repeat_count'] : null;
+            $this->repeatedChar = $params['repeated_char'] ?? null;
+            $this->baseGuesses = $params['base_guesses'] ?? null;
+            $this->baseMatches = $params['base_matches'] ?? null;
+            $this->repeatCount = $params['repeat_count'] ?? null;
         }
     }
 

--- a/src/Matchers/RepeatMatch.php
+++ b/src/Matchers/RepeatMatch.php
@@ -107,10 +107,10 @@ class RepeatMatch extends BaseMatch
     {
         parent::__construct($password, $begin, $end, $token);
         if (!empty($params)) {
-            $this->repeatedChar = $params['repeated_char'] ?? null;
-            $this->baseGuesses = $params['base_guesses'] ?? null;
-            $this->baseMatches = $params['base_matches'] ?? null;
-            $this->repeatCount = $params['repeat_count'] ?? null;
+            $this->repeatedChar = $params['repeated_char'] ?? '';
+            $this->baseGuesses = $params['base_guesses'] ?? 0;
+            $this->baseMatches = $params['base_matches'] ?? [];
+            $this->repeatCount = $params['repeat_count'] ?? 0;
         }
     }
 

--- a/src/Matchers/ReverseDictionaryMatch.php
+++ b/src/Matchers/ReverseDictionaryMatch.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Matchers;
 
+use JetBrains\PhpStorm\ArrayShape;
 use ZxcvbnPhp\Matcher;
 
 class ReverseDictionaryMatch extends DictionaryMatch
@@ -39,6 +42,7 @@ class ReverseDictionaryMatch extends DictionaryMatch
         return parent::getRawGuesses() * 2;
     }
 
+    #[ArrayShape(['warning' => 'string', 'suggestions' => 'string[]'])]
     public function getFeedback(bool $isSoleMatch): array
     {
         $feedback = parent::getFeedback($isSoleMatch);

--- a/src/Matchers/ReverseDictionaryMatch.php
+++ b/src/Matchers/ReverseDictionaryMatch.php
@@ -17,7 +17,7 @@ class ReverseDictionaryMatch extends DictionaryMatch
      * @param array $rankedDictionaries
      * @return ReverseDictionaryMatch[]
      */
-    public static function match($password, array $userInputs = [], $rankedDictionaries = [])
+    public static function match(string $password, array $userInputs = [], array $rankedDictionaries = []): array
     {
         /** @var ReverseDictionaryMatch[] $matches */
         $matches = parent::match(self::mbStrRev($password), $userInputs, $rankedDictionaries);
@@ -34,12 +34,12 @@ class ReverseDictionaryMatch extends DictionaryMatch
         return $matches;
     }
 
-    protected function getRawGuesses()
+    protected function getRawGuesses(): float
     {
         return parent::getRawGuesses() * 2;
     }
 
-    public function getFeedback($isSoleMatch)
+    public function getFeedback(bool $isSoleMatch): array
     {
         $feedback = parent::getFeedback($isSoleMatch);
 
@@ -50,7 +50,7 @@ class ReverseDictionaryMatch extends DictionaryMatch
         return $feedback;
     }
 
-    public static function mbStrRev($string, $encoding = null)
+    public static function mbStrRev(string $string, string $encoding = null): string
     {
         if ($encoding === null) {
             $encoding = mb_detect_encoding($string) ?: 'UTF-8';

--- a/src/Matchers/ReverseDictionaryMatch.php
+++ b/src/Matchers/ReverseDictionaryMatch.php
@@ -34,7 +34,7 @@ class ReverseDictionaryMatch extends DictionaryMatch
         return $matches;
     }
 
-    protected function getRawGuesses(): int
+    protected function getRawGuesses(): float
     {
         return parent::getRawGuesses() * 2;
     }

--- a/src/Matchers/ReverseDictionaryMatch.php
+++ b/src/Matchers/ReverseDictionaryMatch.php
@@ -34,7 +34,7 @@ class ReverseDictionaryMatch extends DictionaryMatch
         return $matches;
     }
 
-    protected function getRawGuesses(): float
+    protected function getRawGuesses(): int
     {
         return parent::getRawGuesses() * 2;
     }

--- a/src/Matchers/SequenceMatch.php
+++ b/src/Matchers/SequenceMatch.php
@@ -1,6 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Matchers;
+
+use JetBrains\PhpStorm\ArrayShape;
 
 class SequenceMatch extends BaseMatch
 {
@@ -83,6 +87,7 @@ class SequenceMatch extends BaseMatch
         }
     }
 
+    #[ArrayShape(['warning' => 'string', 'suggestions' => 'string[]'])]
     public function getFeedback(bool $isSoleMatch): array
     {
         return [

--- a/src/Matchers/SequenceMatch.php
+++ b/src/Matchers/SequenceMatch.php
@@ -104,9 +104,9 @@ class SequenceMatch extends BaseMatch
     {
         parent::__construct($password, $begin, $end, $token);
         if (!empty($params)) {
-            $this->sequenceName = $params['sequenceName'] ?? null;
-            $this->sequenceSpace = $params['sequenceSpace'] ?? null;
-            $this->ascending = $params['ascending'] ?? null;
+            $this->sequenceName = $params['sequenceName'] ?? '';
+            $this->sequenceSpace = $params['sequenceSpace'] ?? 0;
+            $this->ascending = $params['ascending'] ?? false;
         }
     }
 

--- a/src/Matchers/SequenceMatch.php
+++ b/src/Matchers/SequenceMatch.php
@@ -110,7 +110,7 @@ class SequenceMatch extends BaseMatch
         }
     }
 
-    protected function getRawGuesses(): float
+    protected function getRawGuesses(): int
     {
         $firstCharacter = mb_substr($this->token, 0, 1);
         $guesses = 0;

--- a/src/Matchers/SequenceMatch.php
+++ b/src/Matchers/SequenceMatch.php
@@ -24,7 +24,7 @@ class SequenceMatch extends BaseMatch
      * @param array $userInputs
      * @return SequenceMatch[]
      */
-    public static function match($password, array $userInputs = [])
+    public static function match(string $password, array $userInputs = []): array
     {
         $matches = [];
         $passwordLength = mb_strlen($password);
@@ -55,7 +55,7 @@ class SequenceMatch extends BaseMatch
         return $matches;
     }
 
-    public static function findSequenceMatch($password, $begin, $end, $delta, &$matches)
+    public static function findSequenceMatch(string $password, int $begin, int $end, int $delta, array &$matches)
     {
         if ($end - $begin > 1 || abs($delta) === 1) {
             if (abs($delta) > 0 && abs($delta) <= self::MAX_DELTA) {
@@ -79,12 +79,11 @@ class SequenceMatch extends BaseMatch
                     'sequenceSpace' => $sequenceSpace,
                     'ascending' => $delta > 0,
                 ]);
-                return;
             }
         }
     }
 
-    public function getFeedback($isSoleMatch)
+    public function getFeedback(bool $isSoleMatch): array
     {
         return [
             'warning' => "Sequences like abc or 6543 are easy to guess",
@@ -101,7 +100,7 @@ class SequenceMatch extends BaseMatch
      * @param string $token
      * @param array $params An array with keys: [sequenceName, sequenceSpace, ascending].
      */
-    public function __construct($password, $begin, $end, $token, $params = [])
+    public function __construct(string $password, int $begin, int $end, string $token, array $params = [])
     {
         parent::__construct($password, $begin, $end, $token);
         if (!empty($params)) {
@@ -111,7 +110,7 @@ class SequenceMatch extends BaseMatch
         }
     }
 
-    protected function getRawGuesses()
+    protected function getRawGuesses(): float
     {
         $firstCharacter = mb_substr($this->token, 0, 1);
         $guesses = 0;

--- a/src/Matchers/SequenceMatch.php
+++ b/src/Matchers/SequenceMatch.php
@@ -110,7 +110,7 @@ class SequenceMatch extends BaseMatch
         }
     }
 
-    protected function getRawGuesses(): int
+    protected function getRawGuesses(): float
     {
         $firstCharacter = mb_substr($this->token, 0, 1);
         $guesses = 0;

--- a/src/Matchers/SequenceMatch.php
+++ b/src/Matchers/SequenceMatch.php
@@ -29,7 +29,7 @@ class SequenceMatch extends BaseMatch
         $matches = [];
         $passwordLength = mb_strlen($password);
 
-        if ($passwordLength === 1) {
+        if ($passwordLength <= 1) {
             return [];
         }
 

--- a/src/Matchers/SequenceMatch.php
+++ b/src/Matchers/SequenceMatch.php
@@ -104,9 +104,9 @@ class SequenceMatch extends BaseMatch
     {
         parent::__construct($password, $begin, $end, $token);
         if (!empty($params)) {
-            $this->sequenceName = isset($params['sequenceName']) ? $params['sequenceName'] : null;
-            $this->sequenceSpace = isset($params['sequenceSpace']) ? $params['sequenceSpace'] : null;
-            $this->ascending = isset($params['ascending']) ? $params['ascending'] : null;
+            $this->sequenceName = $params['sequenceName'] ?? null;
+            $this->sequenceSpace = $params['sequenceSpace'] ?? null;
+            $this->ascending = $params['ascending'] ?? null;
         }
     }
 

--- a/src/Matchers/SpatialMatch.php
+++ b/src/Matchers/SpatialMatch.php
@@ -214,7 +214,7 @@ class SpatialMatch extends BaseMatch
         return self::$adjacencyGraphs;
     }
 
-    protected function getRawGuesses(): int
+    protected function getRawGuesses(): float
     {
         if ($this->graph === 'qwerty' || $this->graph === 'dvorak') {
             $startingPosition = self::KEYBOARD_STARTING_POSITION;

--- a/src/Matchers/SpatialMatch.php
+++ b/src/Matchers/SpatialMatch.php
@@ -253,6 +253,6 @@ class SpatialMatch extends BaseMatch
             }
         }
 
-        return $guesses;
+        return (int)$guesses;
     }
 }

--- a/src/Matchers/SpatialMatch.php
+++ b/src/Matchers/SpatialMatch.php
@@ -253,6 +253,6 @@ class SpatialMatch extends BaseMatch
             }
         }
 
-        return (int)$guesses;
+        return $guesses > PHP_INT_MAX ? PHP_INT_MAX : (int)$guesses;
     }
 }

--- a/src/Matchers/SpatialMatch.php
+++ b/src/Matchers/SpatialMatch.php
@@ -123,8 +123,11 @@ class SpatialMatch extends BaseMatch
                     $curChar = mb_substr($password, $j, 1);
                     foreach ($adjacents as $adj) {
                         $curDirection += 1;
+                        if ($adj === null) {
+                            continue;
+                        }
                         $curCharPos = static::indexOf($adj, $curChar);
-                        if ($adj !== null && $curCharPos !== -1) {
+                        if ($curCharPos !== -1) {
                             $found = true;
                             $foundDirection = $curDirection;
 
@@ -179,7 +182,7 @@ class SpatialMatch extends BaseMatch
      *
      * @return int
      */
-    protected static function indexOf($string, $char)
+    protected static function indexOf(string $string, string $char): int
     {
         $pos = mb_strpos($string, $char);
         return ($pos === false ? -1 : $pos);

--- a/src/Matchers/SpatialMatch.php
+++ b/src/Matchers/SpatialMatch.php
@@ -214,7 +214,7 @@ class SpatialMatch extends BaseMatch
         return self::$adjacencyGraphs;
     }
 
-    protected function getRawGuesses(): float
+    protected function getRawGuesses(): int
     {
         if ($this->graph === 'qwerty' || $this->graph === 'dvorak') {
             $startingPosition = self::KEYBOARD_STARTING_POSITION;

--- a/src/Matchers/SpatialMatch.php
+++ b/src/Matchers/SpatialMatch.php
@@ -36,7 +36,7 @@ class SpatialMatch extends BaseMatch
      * @param array $graphs
      * @return SpatialMatch[]
      */
-    public static function match($password, array $userInputs = [], array $graphs = [])
+    public static function match(string $password, array $userInputs = [], array $graphs = []): array
     {
 
         $matches = [];
@@ -54,7 +54,7 @@ class SpatialMatch extends BaseMatch
         return $matches;
     }
 
-    public function getFeedback($isSoleMatch)
+    public function getFeedback(bool $isSoleMatch): array
     {
         $warning = $this->turns == 1
             ? 'Straight rows of keys are easy to guess'
@@ -75,7 +75,7 @@ class SpatialMatch extends BaseMatch
      * @param string $token
      * @param array $params An array with keys: [graph (required), shifted_count, turns].
      */
-    public function __construct($password, $begin, $end, $token, $params = [])
+    public function __construct(string $password, int $begin, int $end, string $token, array $params = [])
     {
         parent::__construct($password, $begin, $end, $token);
         $this->graph = $params['graph'];
@@ -190,7 +190,7 @@ class SpatialMatch extends BaseMatch
      *
      * @return array
      */
-    public static function getAdjacencyGraphs()
+    public static function getAdjacencyGraphs(): array
     {
         if (empty(self::$adjacencyGraphs)) {
             $json = file_get_contents(dirname(__FILE__) . '/adjacency_graphs.json');
@@ -211,7 +211,7 @@ class SpatialMatch extends BaseMatch
         return self::$adjacencyGraphs;
     }
 
-    protected function getRawGuesses()
+    protected function getRawGuesses(): float
     {
         if ($this->graph === 'qwerty' || $this->graph === 'dvorak') {
             $startingPosition = self::KEYBOARD_STARTING_POSITION;

--- a/src/Matchers/SpatialMatch.php
+++ b/src/Matchers/SpatialMatch.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Matchers;
 
+use JetBrains\PhpStorm\ArrayShape;
 use ZxcvbnPhp\Matcher;
 
 class SpatialMatch extends BaseMatch
@@ -54,6 +57,7 @@ class SpatialMatch extends BaseMatch
         return $matches;
     }
 
+    #[ArrayShape(['warning' => 'string', 'suggestions' => 'string[]'])]
     public function getFeedback(bool $isSoleMatch): array
     {
         $warning = $this->turns == 1
@@ -242,7 +246,7 @@ class SpatialMatch extends BaseMatch
             $shifted = $this->shiftedCount;
             $unshifted = $length - $shifted;
 
-            if ($shifted === 0 || $unshifted === 0) {
+            if ($unshifted === 0) {
                 $guesses *= 2;
             } else {
                 $variations = 0;
@@ -253,6 +257,6 @@ class SpatialMatch extends BaseMatch
             }
         }
 
-        return $guesses > PHP_INT_MAX ? PHP_INT_MAX : (int)$guesses;
+        return $guesses;
     }
 }

--- a/src/Matchers/SpatialMatch.php
+++ b/src/Matchers/SpatialMatch.php
@@ -80,8 +80,8 @@ class SpatialMatch extends BaseMatch
         parent::__construct($password, $begin, $end, $token);
         $this->graph = $params['graph'];
         if (!empty($params)) {
-            $this->shiftedCount = isset($params['shifted_count']) ? $params['shifted_count'] : null;
-            $this->turns = isset($params['turns']) ? $params['turns'] : null;
+            $this->shiftedCount = $params['shifted_count'] ?? null;
+            $this->turns = $params['turns'] ?? null;
         }
     }
 
@@ -116,7 +116,7 @@ class SpatialMatch extends BaseMatch
                 $prevChar = mb_substr($password, $j - 1, 1);
                 $found = false;
                 $curDirection = -1;
-                $adjacents = isset($graph[$prevChar]) ? $graph[$prevChar] : [];
+                $adjacents = $graph[$prevChar] ?? [];
 
                 // Consider growing pattern by one character if j hasn't gone over the edge.
                 if ($j < $passwordLength) {

--- a/src/Matchers/SpatialMatch.php
+++ b/src/Matchers/SpatialMatch.php
@@ -92,7 +92,7 @@ class SpatialMatch extends BaseMatch
      * @param string $graphName
      * @return array
      */
-    protected static function graphMatch($password, $graph, $graphName)
+    protected static function graphMatch(string $password, array $graph, string $graphName): array
     {
         $result = [];
         $i = 0;

--- a/src/Matchers/YearMatch.php
+++ b/src/Matchers/YearMatch.php
@@ -41,7 +41,7 @@ class YearMatch extends BaseMatch
         ];
     }
 
-    protected function getRawGuesses(): int
+    protected function getRawGuesses(): float
     {
         $yearSpace = abs((int)$this->token - DateMatch::getReferenceYear());
         return max($yearSpace, DateMatch::MIN_YEAR_SPACE);

--- a/src/Matchers/YearMatch.php
+++ b/src/Matchers/YearMatch.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Matchers;
 
+use JetBrains\PhpStorm\ArrayShape;
 use ZxcvbnPhp\Matcher;
 
 class YearMatch extends BaseMatch
@@ -13,7 +16,7 @@ class YearMatch extends BaseMatch
     public $regexName = 'recent_year';
 
     /**
-     * Match occurences of years in a password
+     * Match occurrences of years in a password
      *
      * @param string $password
      * @param array $userInputs
@@ -30,6 +33,7 @@ class YearMatch extends BaseMatch
         return $matches;
     }
 
+    #[ArrayShape(['warning' => 'string', 'suggestions' => 'string[]'])]
     public function getFeedback(bool $isSoleMatch): array
     {
         return [
@@ -43,7 +47,7 @@ class YearMatch extends BaseMatch
 
     protected function getRawGuesses(): float
     {
-        $yearSpace = abs((int)$this->token - DateMatch::getReferenceYear());
+        $yearSpace = abs($this->token - DateMatch::getReferenceYear());
         return max($yearSpace, DateMatch::MIN_YEAR_SPACE);
     }
 }

--- a/src/Matchers/YearMatch.php
+++ b/src/Matchers/YearMatch.php
@@ -19,7 +19,7 @@ class YearMatch extends BaseMatch
      * @param array $userInputs
      * @return YearMatch[]
      */
-    public static function match($password, array $userInputs = [])
+    public static function match(string $password, array $userInputs = []): array
     {
         $matches = [];
         $groups = static::findAll($password, "/(19\d\d|200\d|201\d)/u");
@@ -30,7 +30,7 @@ class YearMatch extends BaseMatch
         return $matches;
     }
 
-    public function getFeedback($isSoleMatch)
+    public function getFeedback(bool $isSoleMatch): array
     {
         return [
             'warning' => "Recent years are easy to guess",
@@ -41,7 +41,7 @@ class YearMatch extends BaseMatch
         ];
     }
 
-    protected function getRawGuesses()
+    protected function getRawGuesses(): float
     {
         $yearSpace = abs((int)$this->token - DateMatch::getReferenceYear());
         return max($yearSpace, DateMatch::MIN_YEAR_SPACE);

--- a/src/Matchers/YearMatch.php
+++ b/src/Matchers/YearMatch.php
@@ -41,7 +41,7 @@ class YearMatch extends BaseMatch
         ];
     }
 
-    protected function getRawGuesses(): float
+    protected function getRawGuesses(): int
     {
         $yearSpace = abs((int)$this->token - DateMatch::getReferenceYear());
         return max($yearSpace, DateMatch::MIN_YEAR_SPACE);

--- a/src/Scorer.php
+++ b/src/Scorer.php
@@ -59,7 +59,7 @@ class Scorer
      * @param bool $excludeAdditive
      * @return array Returns an array with these keys: [password, guesses, guesses_log10, sequence]
      */
-    public function getMostGuessableMatchSequence($password, $matches, $excludeAdditive = false)
+    public function getMostGuessableMatchSequence(string $password, array $matches, bool $excludeAdditive = false): array
     {
         $this->password = $password;
         $this->excludeAdditive = $excludeAdditive;
@@ -136,7 +136,7 @@ class Scorer
      * @param BaseMatch $match
      * @param int $length
      */
-    protected function update($match, $length)
+    protected function update(BaseMatch $match, int $length): void
     {
         $k = $match->end;
 
@@ -184,7 +184,7 @@ class Scorer
      * helper: evaluate bruteforce matches ending at k
      * @param int $end
      */
-    protected function bruteforceUpdate($end)
+    protected function bruteforceUpdate(int $end): void
     {
         // see if a single bruteforce match spanning the k-prefix is optimal.
         $match = $this->makeBruteforceMatch(0, $end);
@@ -217,7 +217,7 @@ class Scorer
      * @param int $end
      * @return Bruteforce
      */
-    protected function makeBruteforceMatch($begin, $end)
+    protected function makeBruteforceMatch(int $begin, int $end): Bruteforce
     {
         return new Bruteforce($this->password, $begin, $end, mb_substr($this->password, $begin, $end - $begin + 1));
     }
@@ -227,7 +227,7 @@ class Scorer
      * @param int $n
      * @return MatchInterface[]
      */
-    protected function unwind($n)
+    protected function unwind(int $n): array
     {
         $optimalSequence = [];
         $k = $n - 1;
@@ -258,7 +258,7 @@ class Scorer
      * @param int $n
      * @return int
      */
-    protected function factorial($n)
+    protected function factorial(int $n): int
     {
         if ($n < 2) {
             return 1;

--- a/src/Scorer.php
+++ b/src/Scorer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp;
 
 use ZxcvbnPhp\Matchers\Bruteforce;
@@ -114,7 +116,7 @@ class Scorer
 
 
         if ($length === 0) {
-            $guesses = 1;
+            $guesses = 1.0;
             $optimalSequence = [];
         } else {
             $optimalSequence = $this->unwind($length);

--- a/src/TimeEstimator.php
+++ b/src/TimeEstimator.php
@@ -35,7 +35,7 @@ class TimeEstimator
         ];
     }
 
-    protected function guessesToScore(float $guesses): int
+    protected function guessesToScore(float $guesses): float
     {
         $DELTA = 5;
 

--- a/src/TimeEstimator.php
+++ b/src/TimeEstimator.php
@@ -10,7 +10,11 @@ namespace ZxcvbnPhp;
  */
 class TimeEstimator
 {
-    public function estimateAttackTimes($guesses)
+    /**
+     * @param int|float $guesses
+     * @return array
+     */
+    public function estimateAttackTimes(float $guesses): array
     {
         $crack_times_seconds = [
             'online_throttling_100_per_hour' => $guesses / (100 / 3600),
@@ -31,7 +35,7 @@ class TimeEstimator
         ];
     }
 
-    protected function guessesToScore($guesses)
+    protected function guessesToScore(float $guesses): int
     {
         $DELTA = 5;
 
@@ -60,7 +64,7 @@ class TimeEstimator
         return 4;
     }
 
-    protected function displayTime($seconds)
+    protected function displayTime(float $seconds): string
     {
         $callback = function ($seconds) {
             $minute = 60;
@@ -107,7 +111,7 @@ class TimeEstimator
             return [null, 'centuries'];
         };
 
-        list($display_num, $display_str) = $callback($seconds);
+        [$display_num, $display_str] = $callback($seconds);
 
         if ($display_num > 1) {
             $display_str .= 's';

--- a/src/TimeEstimator.php
+++ b/src/TimeEstimator.php
@@ -66,7 +66,7 @@ class TimeEstimator
 
     protected function displayTime(float $seconds): string
     {
-        $callback = function ($seconds) {
+        $callback = function (float $seconds): array {
             $minute = 60;
             $hour = $minute * 60;
             $day = $hour * 24;

--- a/src/TimeEstimator.php
+++ b/src/TimeEstimator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp;
 
 /**
@@ -35,7 +37,7 @@ class TimeEstimator
         ];
     }
 
-    protected function guessesToScore(float $guesses): float
+    protected function guessesToScore(float $guesses): int
     {
         $DELTA = 5;
 

--- a/src/Zxcvbn.php
+++ b/src/Zxcvbn.php
@@ -37,7 +37,7 @@ class Zxcvbn
         $this->feedback = new \ZxcvbnPhp\Feedback();
     }
 
-    public function addMatcher(string $className)
+    public function addMatcher(string $className): self
     {
         $this->matcher->addMatcher($className);
 
@@ -56,7 +56,7 @@ class Zxcvbn
      *               match_sequence
      *               score
      */
-    public function passwordStrength($password, array $userInputs = [])
+    public function passwordStrength(string $password, array $userInputs = []): array
     {
         $timeStart = microtime(true);
 

--- a/src/Zxcvbn.php
+++ b/src/Zxcvbn.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp;
 
 /**

--- a/test/FeedbackTest.php
+++ b/test/FeedbackTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Test;
 
 use PHPUnit\Framework\TestCase;
@@ -22,7 +24,7 @@ class FeedbackTest extends TestCase
     {
         $feedback = $this->feedback->getFeedback(0, []);
 
-        $this->assertEquals('', $feedback['warning'], "default warning");
+        $this->assertSame('', $feedback['warning'], "default warning");
         $this->assertContains(
             'Use a few words, avoid common phrases',
             $feedback['suggestions'],
@@ -40,7 +42,7 @@ class FeedbackTest extends TestCase
         $match = new Bruteforce('a', 0, 1, 'a');
         $feedback = $this->feedback->getFeedback(3, [$match]);
 
-        $this->assertEquals('', $feedback['warning'], "no warning for good score");
+        $this->assertSame('', $feedback['warning'], "no warning for good score");
         $this->assertEmpty($feedback['suggestions'], "no suggestions for good score");
     }
 
@@ -55,7 +57,7 @@ class FeedbackTest extends TestCase
         ]);
         $feedback = $this->feedback->getFeedback(1, [$match1, $match2]);
 
-        $this->assertEquals(
+        $this->assertSame(
             'Dates are often easy to guess',
             $feedback['warning'],
             "warning provided for the longest match"
@@ -95,8 +97,8 @@ class FeedbackTest extends TestCase
         $match = new Bruteforce('qkcriv', 0, 6, 'qkcriv');
         $feedback = $this->feedback->getFeedback(1, [$match]);
 
-        $this->assertEquals('', $feedback['warning'], "bruteforce match has no warning");
-        $this->assertEquals(
+        $this->assertSame('', $feedback['warning'], "bruteforce match has no warning");
+        $this->assertSame(
             ['Add another word or two. Uncommon words are better.'],
             $feedback['suggestions'],
             "bruteforce match only has the default suggestion"

--- a/test/MatcherTest.php
+++ b/test/MatcherTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Test;
 
 use PHPUnit\Framework\TestCase;
@@ -62,7 +64,7 @@ class MatcherTest extends TestCase
         $matches = $matcher->getMatches('_wQbgL491', ['PJnD', 'WQBG', 'ZhwZ']);
 
         $this->assertInstanceOf(DictionaryMatch::class, $matches[0], "user input match is correct class");
-        $this->assertEquals('wQbg', $matches[0]->token, "user input match has correct token");
+        $this->assertSame('wQbg', $matches[0]->token, "user input match has correct token");
     }
 
     public function testAddMatcherWillThrowException()

--- a/test/Matchers/AbstractMatchTest.php
+++ b/test/Matchers/AbstractMatchTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Test\Matchers;
 
 use PHPUnit\Framework\TestCase;
@@ -68,7 +70,7 @@ abstract class AbstractMatchTest extends TestCase
             $patternNames = array_fill(0, count($patterns), $patternNames);
         }
 
-        $this->assertEquals(
+        $this->assertSame(
             count($patterns),
             count($matches),
             $prefix . ": matches.length == " . count($patterns)
@@ -80,17 +82,17 @@ abstract class AbstractMatchTest extends TestCase
             $pattern = $patterns[$k];
             list($i, $j) = $ijs[$k];
 
-            $this->assertEquals(
+            $this->assertSame(
                 $patternName,
                 $match->pattern,
                 "$prefix matches[$k].pattern == '$patternName'"
             );
-            $this->assertEquals(
+            $this->assertSame(
                 [$i, $j],
                 [$match->begin, $match->end],
                 "$prefix matches[$k] should have [i, j] of [$i, $j]"
             );
-            $this->assertEquals(
+            $this->assertSame(
                 $pattern,
                 $match->token,
                 "$prefix matches[$k].token == '$pattern'"
@@ -99,7 +101,7 @@ abstract class AbstractMatchTest extends TestCase
             foreach ($props as $propName => $propList) {
                 $propMessage = var_export($propList[$k], true);
                 // prop_msg = "'$prop_msg'" if typeof(prop_msg) == 'string'
-                $this->assertEquals(
+                $this->assertSame(
                     $propList[$k],
                     $match->$propName,
                     "$prefix matches[$k].$propName == $propMessage"

--- a/test/Matchers/BruteforceTest.php
+++ b/test/Matchers/BruteforceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Test\Matchers;
 
 use ZxcvbnPhp\Matchers\Bruteforce;
@@ -45,6 +47,6 @@ class BruteforceTest extends AbstractMatchTest
     {
         $token = '🙂'; // smiley face emoji
         $match = new Bruteforce($token, 0, 1, $token);
-        $this->assertEquals(11, $match->getGuesses(), "multibyte character treated as one character");
+        $this->assertSame(11.0, $match->getGuesses(), "multibyte character treated as one character");
     }
 }

--- a/test/Matchers/DateTest.php
+++ b/test/Matchers/DateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Test\Matchers;
 
 use ZxcvbnPhp\Matchers\DateMatch;
@@ -236,7 +238,7 @@ class DateTest extends AbstractMatchTest
 
     public function testReferenceYearImplementation()
     {
-        $this->assertEquals(date('Y'), DateMatch::getReferenceYear(), "reference year implementation");
+        $this->assertSame((int)date('Y'), DateMatch::getReferenceYear(), "reference year implementation");
     }
 
     public function testNonDateThatLooksLikeDate()
@@ -254,8 +256,8 @@ class DateTest extends AbstractMatchTest
             'day' => 1
         ]);
 
-        $expected = 365 * abs(DateMatch::getReferenceYear() - $match->year);
-        $this->assertEquals(
+        $expected = 365.0 * abs(DateMatch::getReferenceYear() - $match->year);
+        $this->assertSame(
             $expected,
             $match->getGuesses(),
             "guesses for $token is 365 * distance_from_ref_year"
@@ -272,8 +274,8 @@ class DateTest extends AbstractMatchTest
             'day' => 1
         ]);
 
-        $expected = 7300; // 365 * DateMatch::MIN_YEAR_SPACE;
-        $this->assertEquals($expected, $match->getGuesses(), "recent years assume MIN_YEAR_SPACE");
+        $expected = 7300.0; // 365 * DateMatch::MIN_YEAR_SPACE;
+        $this->assertSame($expected, $match->getGuesses(), "recent years assume MIN_YEAR_SPACE");
     }
 
     public function testGuessWithSeparator()
@@ -286,8 +288,8 @@ class DateTest extends AbstractMatchTest
             'day' => 1
         ]);
 
-        $expected = 29200; // 365 * DateMatch::MIN_YEAR_SPACE * 4;
-        $this->assertEquals($expected, $match->getGuesses(), "extra guesses are added for separators");
+        $expected = 29200.0; // 365 * DateMatch::MIN_YEAR_SPACE * 4;
+        $this->assertSame($expected, $match->getGuesses(), "extra guesses are added for separators");
     }
 
     public function testFeedback()
@@ -301,7 +303,7 @@ class DateTest extends AbstractMatchTest
         ]);
         $feedback = $match->getFeedback(true);
 
-        $this->assertEquals(
+        $this->assertSame(
             'Dates are often easy to guess',
             $feedback['warning'],
             "date match gives correct warning"

--- a/test/Matchers/L33tTest.php
+++ b/test/Matchers/L33tTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Test\Matchers;
 
 use ReflectionClass;
@@ -17,7 +19,7 @@ class L33tTest extends AbstractMatchTest
 
     // Generally we only need to test the public interface of the matchers, but it can be useful
     // to occasionally test protected methods to ensure consistency with upstream.
-    protected static function callProtectedMethod($name, $args)
+    protected static function callProtectedMethod(string $name, array $args)
     {
         $class = new ReflectionClass('\\ZxcvbnPhp\\Test\\Matchers\\MockL33tMatch');
         $method = $class->getMethod($name);
@@ -25,7 +27,7 @@ class L33tTest extends AbstractMatchTest
         return $method->invokeArgs(null, $args);
     }
 
-    public function testReducesL33tTable()
+    public function testReducesL33tTable(): void
     {
         $cases = [
             ''      => [] ,
@@ -46,7 +48,7 @@ class L33tTest extends AbstractMatchTest
         ];
 
         foreach ($cases as $pw => $expected) {
-            $this->assertEquals(
+            $this->assertSame(
                 $expected,
                 static::callProtectedMethod('getL33tSubtable', [$pw]),
                 "reduces l33t table to only the substitutions that a password might be employing"
@@ -54,7 +56,7 @@ class L33tTest extends AbstractMatchTest
         }
     }
 
-    public function testEnumeratesL33tSubstitutions()
+    public function testEnumeratesL33tSubstitutions(): void
     {
         $cases = [
             [
@@ -74,7 +76,7 @@ class L33tTest extends AbstractMatchTest
         ];
 
         foreach ($cases as $case) {
-            $this->assertEquals(
+            $this->assertSame(
                 $case[1],
                 static::callProtectedMethod('getL33tSubstitutions', [$case[0]]),
                 "enumerates the different sets of l33t substitutions a password might be using"
@@ -82,43 +84,43 @@ class L33tTest extends AbstractMatchTest
         }
     }
 
-    public function testEmptyString()
+    public function testEmptyString(): void
     {
-        $this->assertEquals(
+        $this->assertSame(
             [],
             L33tMatch::match(''),
             "doesn't match empty string"
         );
     }
 
-    public function testPureDictionaryWords()
+    public function testPureDictionaryWords(): void
     {
-        $this->assertEquals(
+        $this->assertSame(
             [],
             L33tMatch::match('password'),
             "doesn't match pure dictionary words"
         );
     }
 
-    public function testPureDictionaryWordsWithL33tCharactersAfter()
+    public function testPureDictionaryWordsWithL33tCharactersAfter(): void
     {
-        $this->assertEquals(
+        $this->assertSame(
             [],
             L33tMatch::match('password4'),
             "doesn't match pure dictionary word with l33t characters after"
         );
     }
 
-    public function testCapitalizedDictionaryWordsWithL33tCharactersAfter()
+    public function testCapitalizedDictionaryWordsWithL33tCharactersAfter(): void
     {
-        $this->assertEquals(
+        $this->assertSame(
             [],
             L33tMatch::match('Password4'),
             "doesn't match capitalized dictionary word with l33t characters after"
         );
     }
 
-    public function commonCaseProvider()
+    public function commonCaseProvider(): array
     {
         return [
             [
@@ -161,7 +163,7 @@ class L33tTest extends AbstractMatchTest
      * @param int[] $ij
      * @param array $substitutions
      */
-    public function testCommonL33tSubstitutions($password, $pattern, $word, $dictionary, $rank, $ij, $substitutions)
+    public function testCommonL33tSubstitutions(string $password, string $pattern, string $word, string $dictionary, int $rank, array $ij, array $substitutions): void
     {
         $this->checkMatches(
             "matches against common l33t substitutions",
@@ -179,7 +181,7 @@ class L33tTest extends AbstractMatchTest
         );
     }
 
-    public function testOverlappingL33tPatterns()
+    public function testOverlappingL33tPatterns(): void
     {
         $this->checkMatches(
             "matches against overlapping l33t patterns",
@@ -201,25 +203,25 @@ class L33tTest extends AbstractMatchTest
         );
     }
 
-    public function testMultipleL33tSubstitutions()
+    public function testMultipleL33tSubstitutions(): void
     {
-        $this->assertEquals(
+        $this->assertSame(
             [],
             MockL33tMatch::match('p4@ssword'),
             "doesn't match when multiple l33t substitutions are needed for the same letter"
         );
     }
 
-    public function testSingleCharacterL33tWords()
+    public function testSingleCharacterL33tWords(): void
     {
-        $this->assertEquals(
+        $this->assertSame(
             [],
             L33tMatch::match('4 1 @'),
             "doesn't match single-character l33ted words"
         );
     }
 
-    public function testSubstitutionSubsets()
+    public function testSubstitutionSubsets(): void
     {
         // From the coffeescript source:
         //
@@ -232,7 +234,7 @@ class L33tTest extends AbstractMatchTest
         // msg = "doesn't match with subsets of possible l33t substitutions"
         // t.deepEqual lm('4sdf0'), [], msg
 
-        $this->assertEquals(
+        $this->assertSame(
             [],
             MockL33tMatch::match('4sdf0'),
             "doesn't match with subsets of possible l33t substitutions"
@@ -265,27 +267,27 @@ class L33tTest extends AbstractMatchTest
             'rank' => 32,
             'sub' => array('@' => 'a')
         ]);
-        $expected = 32 * 41;    // rank * l33t variations
-        $this->assertEquals($expected, $match->getGuesses(), "guesses are doubled when word is reversed");
+        $expected = 32.0 * 41;    // rank * l33t variations
+        $this->assertSame($expected, $match->getGuesses(), "guesses are doubled when word is reversed");
     }
 
     public function testGuessesL33tAndUppercased()
     {
         $match = new L33tMatch('AaA@@@', 0, 5, 'AaA@@@', [
             'rank' => 32,
-            'sub' => array('@' => 'a')
+            'sub' => ['@' => 'a']
         ]);
-        $expected = 32 * 41 * 3;    // rank * l33t variations * uppercase variations
-        $this->assertEquals(
+        $expected = 32.0 * 41 * 3;    // rank * l33t variations * uppercase variations
+        $this->assertSame(
             $expected,
             $match->getGuesses(),
             "extra guesses are added for both capitalization and common l33t substitutions"
         );
     }
 
-    public function variationsProvider()
+    public function variationsProvider(): array
     {
-        return array(
+        return [
             [ '',  1, [] ],
             [ 'a', 1, [] ],
             [ '4', 2, ['4' => 'a'] ],
@@ -295,22 +297,22 @@ class L33tTest extends AbstractMatchTest
             [ 'a8cet', 2, ['8' => 'b'] ],
             [ 'abce+', 2, ['+' => 't'] ],
             [ '48cet', 4, ['4' => 'a', '8' => 'b'] ],
-            ['a4a4aa', BaseMatch::binom(6, 2) + BaseMatch::binom(6, 1), ['4' => 'a'] ],
-            ['4a4a44', BaseMatch::binom(6, 2) + BaseMatch::binom(6, 1), ['4' => 'a'] ],
-            ['a44att+', (BaseMatch::binom(4, 2) + BaseMatch::binom(4, 1)) * BaseMatch::binom(3, 1), ['4' => 'a', '+' => 't'] ]
-        );
+            ['a4a4aa', /* binom(6, 2) */ 15 + /* binom(6, 1) */ 6, ['4' => 'a']],
+            ['4a4a44', /* binom(6, 2) */ 15 + /* binom(6, 1) */ 6, ['4' => 'a']],
+            ['a44att+', (/* binom(4, 2) */ 6 + /* binom(4, 1) */ 4) * /* binom(3, 1) */ 3, ['4' => 'a', '+' => 't']],
+        ];
     }
 
     /**
      * @dataProvider variationsProvider
-     * @param $token
-     * @param $expectedGuesses
-     * @param $substitutions
+     * @param string $token
+     * @param float  $expectedGuesses
+     * @param array  $substitutions
      */
-    public function testGuessesL33tVariations($token, $expectedGuesses, $substitutions)
+    public function testGuessesL33tVariations(string $token, float $expectedGuesses, array $substitutions): void
     {
         $match = new L33tMatch($token, 0, strlen($token) - 1, $token, ['rank' => 1, 'sub' => $substitutions]);
-        $this->assertEquals(
+        $this->assertSame(
             $expectedGuesses,
             $match->getGuesses(),
             "extra l33t guesses of $token is $expectedGuesses"
@@ -321,21 +323,22 @@ class L33tTest extends AbstractMatchTest
      * This test is not strictly needed as it's testing an internal detail, but it's included to match an upstream test.
      * @link https://github.com/dropbox/zxcvbn/blob/master/test/test-scoring.coffee#L357
      */
-    public function testCapitalisationNotAffectingL33t()
+    public function testCapitalisationNotAffectingL33t(): void
     {
         $token = 'Aa44aA';
         $match = new L33tMatch($token, 0, strlen($token) - 1, $token, ['rank' => 1, 'sub' => ['4' => 'a']]);
-        $expected = BaseMatch::binom(6, 2) + BaseMatch::binom(6, 1);
+        // binom(6, 2) + binom(6, 1)
+        $expected = 15.0 + 6;
 
-        $class = new ReflectionClass('\\ZxcvbnPhp\\Matchers\\L33tMatch');
+        $class = new ReflectionClass(L33tMatch::class);
         $method = $class->getMethod('getL33tVariations');
         $method->setAccessible(true);
         $actual = $method->invoke($match);
 
-        $this->assertEquals($expected, $actual, "capitalization doesn't affect extra l33t guesses calc");
+        $this->assertSame($expected, $actual, "capitalization doesn't affect extra l33t guesses calc");
     }
 
-    public function testFeedback()
+    public function testFeedback(): void
     {
         $token = 'univer5ity';
         $match = new L33tMatch($token, 0, strlen($token) - 1, $token, [
@@ -345,7 +348,7 @@ class L33tTest extends AbstractMatchTest
         ]);
         $feedback = $match->getFeedback(true);
 
-        $this->assertEquals(
+        $this->assertSame(
             'A word by itself is easy to guess',
             $feedback['warning'],
             "l33t match didn't lose the original dictionary match warning"
@@ -357,7 +360,7 @@ class L33tTest extends AbstractMatchTest
         );
     }
 
-    public function testFeedbackTop100Password()
+    public function testFeedbackTop100Password(): void
     {
         $token = 'hunt3r';
         $match = new L33tMatch($token, 0, strlen($token) - 1, $token, [
@@ -367,7 +370,7 @@ class L33tTest extends AbstractMatchTest
         ]);
         $feedback = $match->getFeedback(true);
 
-        $this->assertEquals(
+        $this->assertSame(
             'This is similar to a commonly used password',
             $feedback['warning'],
             "l33t match doesn't give top-100 warning"

--- a/test/Matchers/MatchTest.php
+++ b/test/Matchers/MatchTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Test\Matchers;
 
 use PHPUnit\Framework\MockObject\MockObject;
@@ -21,18 +23,22 @@ class MatchTest extends TestCase
             [2, 1, 2],
             [4, 2, 6],
             [33, 7, 4272048],
+            [206, 202, 72867865],
+            [3, 5, 0],
+            [29847, 2, 445406781],
         ];
     }
 
     /**
      * @dataProvider binomialDataProvider
-     * @param $n
-     * @param $k
-     * @param $expected
+     * @param int $n
+     * @param int $k
+     * @param int $expected
      */
-    public function testBinomialCoefficient($n, $k, $expected)
+    public function testBinomialCoefficient(int $n, int $k, int $expected)
     {
-        $this->assertEquals($expected, BaseMatch::binom($n, $k), "binom returns expected result");
+        $this->assertSame($expected, BaseMatch::binom($n, $k), "binom returns expected result");
+        $this->assertSame($expected, BaseMatch::binomPolyfill($n, $k), "binomPolyfill returns expected result");
     }
 
     public function testBinomialMirrorIdentity()
@@ -40,7 +46,7 @@ class MatchTest extends TestCase
         $n = 49;
         $k = 12;
 
-        $this->assertEquals(
+        $this->assertSame(
             BaseMatch::binom($n, $k),
             BaseMatch::binom($n, $n - $k),
             "mirror identity"
@@ -52,7 +58,7 @@ class MatchTest extends TestCase
         $n = 49;
         $k = 12;
 
-        $this->assertEquals(
+        $this->assertSame(
             BaseMatch::binom($n, $k),
             BaseMatch::binom($n - 1, $k - 1) + BaseMatch::binom($n - 1, $k),
             "pascal's triangle identity"
@@ -60,38 +66,41 @@ class MatchTest extends TestCase
     }
 
     /**
-     * @param int $guesses
-     * @return \PHPUnit_Framework_MockObject_MockObject|Match
+     * @param float $guesses
+     * @return MockObject|DateMatch
      */
-    private function getMatchMock($guesses)
+    private function getMatchMock(float $guesses)
     {
         $stub = $this->getMockBuilder(DateMatch::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getGuesses'])
+            ->onlyMethods(['getGuesses'])
             ->getMock();
         $stub->method('getGuesses')->willReturn($guesses);
 
         return $stub;
     }
 
-    public function log10Provider()
+    /**
+     * @return float[][]
+     */
+    public function log10Provider(): array
     {
         return [
-            [1, 0],
-            [10, 1],
-            [100, 2],
-            [500, log10(500)],
+            [1.0, 0.0],
+            [10.0, 1.0],
+            [100.0, 2.0],
+            [500.0, log10(500)],
         ];
     }
 
     /**
      * @dataProvider log10Provider
-     * @param $n
-     * @param $expected
+     * @param float $n
+     * @param float $expected
      */
-    public function testGuessesLog10($n, $expected)
+    public function testGuessesLog10(float $n, float $expected): void
     {
         $stub = $this->getMatchMock($n);
-        $this->assertEquals($expected, $stub->getGuessesLog10(), "log10 guesses");
+        $this->assertSame($expected, $stub->getGuessesLog10(), "log10 guesses");
     }
 }

--- a/test/Matchers/MockL33tMatch.php
+++ b/test/Matchers/MockL33tMatch.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Test\Matchers;
 
 use ZxcvbnPhp\Matchers\L33tMatch;

--- a/test/Matchers/MockL33tMatch.php
+++ b/test/Matchers/MockL33tMatch.php
@@ -6,7 +6,7 @@ use ZxcvbnPhp\Matchers\L33tMatch;
 
 class MockL33tMatch extends L33tMatch
 {
-    protected static function getRankedDictionaries()
+    protected static function getRankedDictionaries(): array
     {
         return [
             'words' => [
@@ -21,7 +21,7 @@ class MockL33tMatch extends L33tMatch
         ];
     }
 
-    protected static function getL33tTable()
+    protected static function getL33tTable(): array
     {
         return [
             'a' => ['4', '@'],

--- a/test/Matchers/MockMatch.php
+++ b/test/Matchers/MockMatch.php
@@ -26,10 +26,7 @@ class MockMatch extends BaseMatch
         return [];
     }
 
-    /**
-     * @return integer
-     */
-    public function getRawGuesses(): float
+    public function getRawGuesses(): int
     {
         return $this->guesses;
     }

--- a/test/Matchers/MockMatch.php
+++ b/test/Matchers/MockMatch.php
@@ -8,7 +8,7 @@ class MockMatch extends BaseMatch
 {
     protected $guesses;
 
-    public function __construct($begin, $end, $guesses)
+    public function __construct(int $begin, int $end, int $guesses)
     {
         parent::__construct('', $begin, $end, '');
         $this->guesses = $guesses;
@@ -21,7 +21,7 @@ class MockMatch extends BaseMatch
      * @return array
      *   Associative array with warning (string) and suggestions (array of strings)
      */
-    public function getFeedback($isSoleMatch)
+    public function getFeedback(bool $isSoleMatch): array
     {
         return [];
     }
@@ -29,7 +29,7 @@ class MockMatch extends BaseMatch
     /**
      * @return integer
      */
-    public function getRawGuesses()
+    public function getRawGuesses(): float
     {
         return $this->guesses;
     }
@@ -47,7 +47,7 @@ class MockMatch extends BaseMatch
      * @return array
      *   Array of Match objects
      */
-    public static function match($password, array $userInputs = [])
+    public static function match(string $password, array $userInputs = []): array
     {
         return [];
     }

--- a/test/Matchers/MockMatch.php
+++ b/test/Matchers/MockMatch.php
@@ -6,9 +6,10 @@ use ZxcvbnPhp\Matchers\BaseMatch;
 
 class MockMatch extends BaseMatch
 {
+    /** @var float */
     protected $guesses;
 
-    public function __construct(int $begin, int $end, int $guesses)
+    public function __construct(int $begin, int $end, float $guesses)
     {
         parent::__construct('', $begin, $end, '');
         $this->guesses = $guesses;
@@ -26,7 +27,7 @@ class MockMatch extends BaseMatch
         return [];
     }
 
-    public function getRawGuesses(): int
+    public function getRawGuesses(): float
     {
         return $this->guesses;
     }

--- a/test/Matchers/MockMatch.php
+++ b/test/Matchers/MockMatch.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Test\Matchers;
 
+use JetBrains\PhpStorm\ArrayShape;
 use ZxcvbnPhp\Matchers\BaseMatch;
 
 class MockMatch extends BaseMatch
@@ -22,9 +25,13 @@ class MockMatch extends BaseMatch
      * @return array
      *   Associative array with warning (string) and suggestions (array of strings)
      */
+    #[ArrayShape(['warning' => 'string', 'suggestions' => 'string[]'])]
     public function getFeedback(bool $isSoleMatch): array
     {
-        return [];
+        return [
+            'warning' => '',
+            'suggestions' => [],
+        ];
     }
 
     public function getRawGuesses(): float

--- a/test/Matchers/RepeatTest.php
+++ b/test/Matchers/RepeatTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Test\Matchers;
 
 use ZxcvbnPhp\Matcher;
@@ -29,7 +31,7 @@ class RepeatTest extends AbstractMatchTest
         $suffixes = ['u', 'u%7'];
         $pattern = '&&&&&';
 
-        foreach ($this->generatePasswords($pattern, $prefixes, $suffixes) as list($password, $i, $j)) {
+        foreach ($this->generatePasswords($pattern, $prefixes, $suffixes) as [$password, $i, $j]) {
             $this->checkMatches(
                 "matches embedded repeat patterns",
                 RepeatMatch::match($password),
@@ -159,7 +161,7 @@ class RepeatTest extends AbstractMatchTest
             [
                 'repeatedChar' => ['abc'],
                 'repeatCount' => [2],
-                'baseGuesses' => [13]
+                'baseGuesses' => [13.0]
             ]
         );
     }
@@ -204,7 +206,7 @@ class RepeatTest extends AbstractMatchTest
         $match = RepeatMatch::match($pattern)[0];
 
         $baseMatches = $match->baseMatches;
-        $this->assertEquals(1, count($baseMatches));
+        $this->assertSame(1, count($baseMatches));
         $this->assertInstanceOf(SequenceMatch::class, $baseMatches[0]);
     }
 
@@ -212,14 +214,14 @@ class RepeatTest extends AbstractMatchTest
     {
         $pattern = 'mqmqmqltltltmqmqmqltltlt';
         $match = RepeatMatch::match($pattern)[0];
-        $this->assertEquals('mqmqmqltltlt', $match->repeatedChar);
+        $this->assertSame('mqmqmqltltlt', $match->repeatedChar);
 
         $baseMatches = $match->baseMatches;
         $this->assertInstanceOf(RepeatMatch::class, $baseMatches[0]);
-        $this->assertEquals('mq', $baseMatches[0]->repeatedChar);
+        $this->assertSame('mq', $baseMatches[0]->repeatedChar);
 
         $this->assertInstanceOf(RepeatMatch::class, $baseMatches[1]);
-        $this->assertEquals('lt', $baseMatches[1]->repeatedChar);
+        $this->assertSame('lt', $baseMatches[1]->repeatedChar);
     }
 
     public function testDuplicateRepeatsInPassword()
@@ -251,12 +253,12 @@ class RepeatTest extends AbstractMatchTest
 
     /**
      * @dataProvider guessesProvider
-     * @param $token
-     * @param $repeatedChar
-     * @param $repeatCount
-     * @param $expectedGuesses
+     * @param string $token
+     * @param string $repeatedChar
+     * @param int    $repeatCount
+     * @param float  $expectedGuesses
      */
-    public function testGuesses($token, $repeatedChar, $repeatCount, $expectedGuesses)
+    public function testGuesses(string $token, string $repeatedChar, int $repeatCount, float $expectedGuesses): void
     {
         $scorer = new Scorer();
         $matcher = new Matcher();
@@ -269,7 +271,7 @@ class RepeatTest extends AbstractMatchTest
             'base_guesses' => $baseGuesses,
         ]);
 
-        self::assertEquals($expectedGuesses, $match->getGuesses(), "the repeat pattern {$token} has guesses of {$expectedGuesses}");
+        self::assertSame($expectedGuesses, $match->getGuesses(), "the repeat pattern {$token} has guesses of {$expectedGuesses}");
     }
 
     public function testFeedbackSingleCharacterRepeat()
@@ -281,7 +283,7 @@ class RepeatTest extends AbstractMatchTest
         ]);
         $feedback = $match->getFeedback(true);
 
-        $this->assertEquals(
+        $this->assertSame(
             'Repeats like "aaa" are easy to guess',
             $feedback['warning'],
             "one repeated character gives correct warning"
@@ -302,7 +304,7 @@ class RepeatTest extends AbstractMatchTest
         ]);
         $feedback = $match->getFeedback(true);
 
-        $this->assertEquals(
+        $this->assertSame(
             'Repeats like "abcabcabc" are only slightly harder to guess than "abc"',
             $feedback['warning'],
             "multiple repeated characters gives correct warning"

--- a/test/Matchers/ReverseDictionaryTest.php
+++ b/test/Matchers/ReverseDictionaryTest.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Test\Matchers;
 
 use ZxcvbnPhp\Matchers\ReverseDictionaryMatch;
 
-class RerverseDictionaryTest extends AbstractMatchTest
+class ReverseDictionaryTest extends AbstractMatchTest
 {
     protected static $testDicts = [
         'd1' => [
@@ -37,8 +39,8 @@ class RerverseDictionaryTest extends AbstractMatchTest
     public function testGuessesReversed()
     {
         $match = new ReverseDictionaryMatch('aaa', 0, 2, 'aaa', ['rank' => 32]);
-        $expected = 32 * 2;     // rank * reversed
-        $this->assertEquals($expected, $match->getGuesses(), "guesses are doubled when word is reversed");
+        $expected = 32.0 * 2;     // rank * reversed
+        $this->assertSame($expected, $match->getGuesses(), "guesses are doubled when word is reversed");
     }
 
     public function testFeedback()
@@ -50,7 +52,7 @@ class RerverseDictionaryTest extends AbstractMatchTest
         ]);
         $feedback = $match->getFeedback(true);
 
-        $this->assertEquals(
+        $this->assertSame(
             'A word by itself is easy to guess',
             $feedback['warning'],
             "reverse dictionary match didn't lose the original dictionary match warning"
@@ -71,7 +73,7 @@ class RerverseDictionaryTest extends AbstractMatchTest
         ]);
         $feedback = $match->getFeedback(true);
 
-        $this->assertEquals(
+        $this->assertSame(
             'This is similar to a commonly used password',
             $feedback['warning'],
             "reverse dictionary match doesn't give top-100 warning"
@@ -87,7 +89,7 @@ class RerverseDictionaryTest extends AbstractMatchTest
         ]);
         $feedback = $match->getFeedback(true);
 
-        $this->assertEquals(
+        $this->assertSame(
             'A word by itself is easy to guess',
             $feedback['warning'],
             "reverse dictionary match still gives warning for short token"

--- a/test/Matchers/SequenceTest.php
+++ b/test/Matchers/SequenceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Test\Matchers;
 
 use ZxcvbnPhp\Matchers\SequenceMatch;
@@ -175,14 +177,14 @@ class SequenceTest extends AbstractMatchTest
 
     /**
      * @dataProvider guessProvider
-     * @param $token
-     * @param $ascending
-     * @param $expectedGuesses
+     * @param string $token
+     * @param bool $ascending
+     * @param float $expectedGuesses
      */
-    public function testGuesses($token, $ascending, $expectedGuesses)
+    public function testGuesses(string $token, bool $ascending, float $expectedGuesses): void
     {
         $match = new SequenceMatch($token, 0, strlen($token) - 1, $token, ['ascending' => $ascending]);
-        $this->assertEquals(
+        $this->assertSame(
             $expectedGuesses,
             $match->getGuesses(),
             "the sequence pattern '$token' has guesses of $expectedGuesses"
@@ -195,13 +197,13 @@ class SequenceTest extends AbstractMatchTest
         $match = new SequenceMatch($token, 0, strlen($token) - 1, $token, ['ascending' => true]);
         $feedback = $match->getFeedback(true);
 
-        $this->assertEquals(
+        $this->assertSame(
             'Sequences like abc or 6543 are easy to guess',
             $feedback['warning'],
             "sequence gives correct warning"
         );
-        $this->assertContains(
-            'Avoid sequences',
+        $this->assertSame(
+            ['Avoid sequences'],
             $feedback['suggestions'],
             "sequence gives correct suggestion"
         );

--- a/test/Matchers/SpatialTest.php
+++ b/test/Matchers/SpatialTest.php
@@ -126,7 +126,7 @@ class SpatialTest extends AbstractMatchTest
         );
     }
 
-    protected function getBaseGuessCount($token)
+    protected function getBaseGuessCount($token): int
     {
         // KEYBOARD_STARTING_POSITIONS * KEYBOARD_AVERAGE_DEGREE * (length - 1)
         // - 1 term because: not counting spatial patterns of length 1
@@ -187,12 +187,12 @@ class SpatialTest extends AbstractMatchTest
     public function complexGuessProvider()
     {
         return [
-            ['6yhgf',        2, 19596.255319547865],
-            ['asde3w',       3, 203315.1579961936],
-            ['zxcft6yh',     3, 558460.6174911747],
-            ['xcvgy7uj',     3, 558460.6174911747],
-            ['ertghjm,.',    5, 30160744.32861352],
-            ['qwerfdsazxcv', 5, 175281377.64553562],
+            ['6yhgf',        2, 19596],
+            ['asde3w',       3, 203315],
+            ['zxcft6yh',     3, 558460],
+            ['xcvgy7uj',     3, 558460],
+            ['ertghjm,.',    5, 30160744],
+            ['qwerfdsazxcv', 5, 175281377],
         ];
     }
 

--- a/test/Matchers/SpatialTest.php
+++ b/test/Matchers/SpatialTest.php
@@ -126,14 +126,14 @@ class SpatialTest extends AbstractMatchTest
         );
     }
 
-    protected function getBaseGuessCount($token): int
+    protected function getBaseGuessCount($token): float
     {
         // KEYBOARD_STARTING_POSITIONS * KEYBOARD_AVERAGE_DEGREE * (length - 1)
         // - 1 term because: not counting spatial patterns of length 1
         // eg for length==6, multiplier is 5 for needing to try len2,len3,..,len6
-        return (int)(SpatialMatch::KEYBOARD_STARTING_POSITION
+        return SpatialMatch::KEYBOARD_STARTING_POSITION
             * SpatialMatch::KEYBOARD_AVERAGE_DEGREES
-            * (strlen($token) - 1));
+            * (strlen($token) - 1);
     }
 
     public function testGuessesBasic()

--- a/test/Matchers/SpatialTest.php
+++ b/test/Matchers/SpatialTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Test\Matchers;
 
 use ZxcvbnPhp\Matchers\BaseMatch;
@@ -10,7 +12,10 @@ use ZxcvbnPhp\Matchers\SpatialMatch;
  */
 class SpatialTest extends AbstractMatchTest
 {
-    public function shortPatternDataProvider()
+    /**
+     * @return string[][]
+     */
+    public function shortPatternDataProvider(): array
     {
         return [
             [''],
@@ -22,27 +27,27 @@ class SpatialTest extends AbstractMatchTest
 
     /**
      * @dataProvider shortPatternDataProvider
-     * @param $password
+     * @param string $password
      */
-    public function testShortPatterns($password)
+    public function testShortPatterns(string $password): void
     {
-        $this->assertEquals(
+        $this->assertSame(
             [],
             SpatialMatch::match($password),
             "doesn't match 1- and 2-character spatial patterns"
         );
     }
 
-    public function testNoPattern()
+    public function testNoPattern(): void
     {
-        $this->assertEquals(
+        $this->assertSame(
             [],
             SpatialMatch::match('qzpm'),
             "doesn't match non-pattern"
         );
     }
 
-    public function testSurroundedPattern()
+    public function testSurroundedPattern(): void
     {
         $pattern = "6tfGHJ";
         $password = "rz!{$pattern}%z";
@@ -64,7 +69,7 @@ class SpatialTest extends AbstractMatchTest
         );
     }
 
-    public function spatialDataProvider()
+    public function spatialDataProvider(): array
     {
         return [
             ['12345',        'qwerty',     1, 0],
@@ -86,12 +91,12 @@ class SpatialTest extends AbstractMatchTest
 
     /**
      * @dataProvider spatialDataProvider
-     * @param $password
-     * @param $keyboard
-     * @param $turns
-     * @param $shifts
+     * @param string $password
+     * @param string $keyboard
+     * @param int    $turns
+     * @param int    $shifts
      */
-    public function testSpatialPatterns($password, $keyboard, $turns, $shifts)
+    public function testSpatialPatterns(string $password, string $keyboard, int $turns, int $shifts): void
     {
         $graphs = [$keyboard => SpatialMatch::getAdjacencyGraphs()[$keyboard]];
 
@@ -109,7 +114,7 @@ class SpatialTest extends AbstractMatchTest
         );
     }
 
-    public function testShiftedCountForMultipleMatches()
+    public function testShiftedCountForMultipleMatches(): void
     {
         $password = "!QAZ1qaz";
         $this->checkMatches(
@@ -126,7 +131,7 @@ class SpatialTest extends AbstractMatchTest
         );
     }
 
-    protected function getBaseGuessCount($token): float
+    protected function getBaseGuessCount(string $token): float
     {
         // KEYBOARD_STARTING_POSITIONS * KEYBOARD_AVERAGE_DEGREE * (length - 1)
         // - 1 term because: not counting spatial patterns of length 1
@@ -136,7 +141,7 @@ class SpatialTest extends AbstractMatchTest
             * (strlen($token) - 1);
     }
 
-    public function testGuessesBasic()
+    public function testGuessesBasic(): void
     {
         $token = 'zxcvbn';
         $match = new SpatialMatch($token, 0, strlen($token) - 1, $token, [
@@ -145,14 +150,14 @@ class SpatialTest extends AbstractMatchTest
             'shifted_count' => 0,
         ]);
 
-        $this->assertEquals(
-            (int)$this->getBaseGuessCount($token),
-            (int)$match->getGuesses(),
+        $this->assertSame(
+            $this->getBaseGuessCount($token),
+            $match->getGuesses(),
             "with no turns or shifts, guesses is starts * degree * (len-1)"
         );
     }
 
-    public function testGuessesShifted()
+    public function testGuessesShifted(): void
     {
         $token = 'ZxCvbn';
         $match = new SpatialMatch($token, 0, strlen($token) - 1, $token, [
@@ -161,14 +166,14 @@ class SpatialTest extends AbstractMatchTest
             'shifted_count' => 2,
         ]);
 
-        $this->assertEquals(
-            (int)$this->getBaseGuessCount($token) * (BaseMatch::binom(6, 2) + BaseMatch::binom(6, 1)),
-            (int)$match->getGuesses(),
+        $this->assertSame(
+            $this->getBaseGuessCount($token) * (BaseMatch::binom(6, 2) + BaseMatch::binom(6, 1)),
+            $match->getGuesses(),
             "guesses is added for shifted keys, similar to capitals in dictionary matching"
         );
     }
 
-    public function testGuessesEverythingShifted()
+    public function testGuessesEverythingShifted(): void
     {
         $token = 'ZXCVBN';
         $match = new SpatialMatch($token, 0, strlen($token) - 1, $token, [
@@ -177,14 +182,17 @@ class SpatialTest extends AbstractMatchTest
             'shifted_count' => 6,
         ]);
 
-        $this->assertEquals(
-            (int)$this->getBaseGuessCount($token) * 2,
-            (int)$match->getGuesses(),
+        $this->assertSame(
+            $this->getBaseGuessCount($token) * 2,
+            $match->getGuesses(),
             "when everything is shifted, guesses are double"
         );
     }
 
-    public function complexGuessProvider()
+    /**
+     * @return array[]
+     */
+    public function complexGuessProvider(): array
     {
         return [
             ['6yhgf',        2, 19596],
@@ -202,7 +210,7 @@ class SpatialTest extends AbstractMatchTest
      * @param int $turns
      * @param float $expected
      */
-    public function testGuessesComplexCase($token, $turns, $expected)
+    public function testGuessesComplexCase(string $token, int $turns, float $expected): void
     {
         $match = new SpatialMatch($token, 0, strlen($token) - 1, $token, [
             'graph' => 'qwerty',
@@ -210,14 +218,18 @@ class SpatialTest extends AbstractMatchTest
             'shifted_count' => 0,
         ]);
 
-        $this->assertEquals(
+        $actual = $match->getGuesses();
+        $this->assertIsFloat($actual);
+
+        $this->assertEqualsWithDelta(
             $expected,
-            $match->getGuesses(),
+            $actual,
+            1.0,
             "spatial guesses accounts for turn positions, directions and starting keys"
         );
     }
 
-    public function testFeedbackStraightLine()
+    public function testFeedbackStraightLine(): void
     {
         $token = 'dfghjk';
         $match = new SpatialMatch($token, 0, strlen($token) - 1, $token, [
@@ -227,7 +239,7 @@ class SpatialTest extends AbstractMatchTest
         ]);
         $feedback = $match->getFeedback(true);
 
-        $this->assertEquals(
+        $this->assertSame(
             'Straight rows of keys are easy to guess',
             $feedback['warning'],
             "spatial match in straight line gives correct warning"
@@ -239,7 +251,7 @@ class SpatialTest extends AbstractMatchTest
         );
     }
 
-    public function testFeedbackWithTurns()
+    public function testFeedbackWithTurns(): void
     {
         $token = 'xcvgy789';
         $match = new SpatialMatch($token, 0, strlen($token) - 1, $token, [
@@ -249,7 +261,7 @@ class SpatialTest extends AbstractMatchTest
         ]);
         $feedback = $match->getFeedback(true);
 
-        $this->assertEquals(
+        $this->assertSame(
             'Short keyboard patterns are easy to guess',
             $feedback['warning'],
             "spatial match with turns gives correct warning"

--- a/test/Matchers/SpatialTest.php
+++ b/test/Matchers/SpatialTest.php
@@ -146,8 +146,8 @@ class SpatialTest extends AbstractMatchTest
         ]);
 
         $this->assertEquals(
-            $this->getBaseGuessCount($token),
-            $match->getGuesses(),
+            (int)$this->getBaseGuessCount($token),
+            (int)$match->getGuesses(),
             "with no turns or shifts, guesses is starts * degree * (len-1)"
         );
     }
@@ -162,8 +162,8 @@ class SpatialTest extends AbstractMatchTest
         ]);
 
         $this->assertEquals(
-            $this->getBaseGuessCount($token) * (BaseMatch::binom(6, 2) + BaseMatch::binom(6, 1)),
-            $match->getGuesses(),
+            (int)$this->getBaseGuessCount($token) * (BaseMatch::binom(6, 2) + BaseMatch::binom(6, 1)),
+            (int)$match->getGuesses(),
             "guesses is added for shifted keys, similar to capitals in dictionary matching"
         );
     }
@@ -178,8 +178,8 @@ class SpatialTest extends AbstractMatchTest
         ]);
 
         $this->assertEquals(
-            $this->getBaseGuessCount($token) * 2,
-            $match->getGuesses(),
+            (int)$this->getBaseGuessCount($token) * 2,
+            (int)$match->getGuesses(),
             "when everything is shifted, guesses are double"
         );
     }

--- a/test/Matchers/SpatialTest.php
+++ b/test/Matchers/SpatialTest.php
@@ -131,9 +131,9 @@ class SpatialTest extends AbstractMatchTest
         // KEYBOARD_STARTING_POSITIONS * KEYBOARD_AVERAGE_DEGREE * (length - 1)
         // - 1 term because: not counting spatial patterns of length 1
         // eg for length==6, multiplier is 5 for needing to try len2,len3,..,len6
-        return SpatialMatch::KEYBOARD_STARTING_POSITION
+        return (int)(SpatialMatch::KEYBOARD_STARTING_POSITION
             * SpatialMatch::KEYBOARD_AVERAGE_DEGREES
-            * (strlen($token) - 1);
+            * (strlen($token) - 1));
     }
 
     public function testGuessesBasic()

--- a/test/Matchers/YearTest.php
+++ b/test/Matchers/YearTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Test\Matchers;
 
 use ZxcvbnPhp\Matchers\DateMatch;
@@ -101,8 +103,8 @@ class YearTest extends AbstractMatchTest
         $token = '1972';
         $match = new YearMatch($token, 0, 3, $token);
 
-        $this->assertEquals(
-            DateMatch::getReferenceYear() - (int)$token,
+        $this->assertSame(
+            (float)(DateMatch::getReferenceYear() - (int)$token),
             $match->getGuesses(),
             "guesses of |year - REFERENCE_YEAR| for past year matches"
         );
@@ -113,8 +115,8 @@ class YearTest extends AbstractMatchTest
         $token = '2050';
         $match = new YearMatch($token, 0, 3, $token);
 
-        $this->assertEquals(
-            (int)$token - DateMatch::getReferenceYear(),
+        $this->assertSame(
+            (float)((int)$token - DateMatch::getReferenceYear()),
             $match->getGuesses(),
             "guesses of |year - REFERENCE_YEAR| for future year matches"
         );
@@ -125,8 +127,8 @@ class YearTest extends AbstractMatchTest
         $token = '2005';
         $match = new YearMatch($token, 0, 3, $token);
 
-        $this->assertEquals(
-            20, // DateMatch::MIN_YEAR_SPACE
+        $this->assertSame(
+            20.0, // DateMatch::MIN_YEAR_SPACE
             $match->getGuesses(),
             "guesses of MIN_YEAR_SPACE for a year close to REFERENCE_YEAR"
         );
@@ -138,7 +140,7 @@ class YearTest extends AbstractMatchTest
         $match = new YearMatch($token, 0, strlen($token) - 1, $token);
         $feedback = $match->getFeedback(true);
 
-        $this->assertEquals(
+        $this->assertSame(
             'Recent years are easy to guess',
             $feedback['warning'],
             "year match gives correct warning"

--- a/test/ScorerTest.php
+++ b/test/ScorerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Test;
 
 use PHPUnit\Framework\TestCase;
@@ -21,23 +23,28 @@ class ScorerTest extends TestCase
         $this->scorer = new Scorer();
     }
 
+    public function testStrictAssertions()
+    {
+        $this->assertNotSame(1, 1.0);
+    }
+
     public function testBlankPassword()
     {
         $result = $this->scorer->getMostGuessableMatchSequence('', []);
-        $this->assertEquals(1, $result['guesses']);
+        $this->assertSame(1.0, $result['guesses']);
         $this->assertEmpty($result['sequence']);
     }
 
     public function testEmptyMatchSequence()
     {
         $result = $this->scorer->getMostGuessableMatchSequence(self::PASSWORD, []);
-        $this->assertEquals(1, count($result['sequence']), "result.sequence.length == 1");
-        $this->assertEquals(10000000001, $result['guesses'], "result.guesses == 10000000001");
+        $this->assertSame(1, count($result['sequence']), "result.sequence.length == 1");
+        $this->assertSame(10000000001.0, $result['guesses'], "result.guesses == 10000000001");
 
         $match = $result['sequence'][0];
-        $this->assertEquals('bruteforce', $match->pattern, "match.pattern == 'bruteforce'");
-        $this->assertEquals(self::PASSWORD, $match->token, "match.token == " . self::PASSWORD);
-        $this->assertEquals([0, 9], [$match->begin, $match->end], "[i, j] == [0, 9]");
+        $this->assertSame('bruteforce', $match->pattern, "match.pattern == 'bruteforce'");
+        $this->assertSame(self::PASSWORD, $match->token, "match.token == " . self::PASSWORD);
+        $this->assertSame([0, 9], [$match->begin, $match->end], "[i, j] == [0, 9]");
     }
 
     public function testMatchAndBruteforceWithPrefix()
@@ -45,13 +52,13 @@ class ScorerTest extends TestCase
         $match = new MockMatch(0, 5, 1);
 
         $result = $this->scorer->getMostGuessableMatchSequence(self::PASSWORD, [$match], true);
-        $this->assertEquals(2, count($result['sequence']), "result.sequence.length == 2");
-        $this->assertEquals($match, $result['sequence'][0], "first match is the provided match object");
+        $this->assertSame(2, count($result['sequence']), "result.sequence.length == 2");
+        $this->assertSame($match, $result['sequence'][0], "first match is the provided match object");
 
         $match1 = $result['sequence'][1];
 
-        $this->assertEquals('bruteforce', $match1->pattern, "second match is bruteforce");
-        $this->assertEquals([6, 9], [$match1->begin, $match1->end], "second match covers full suffix after first match");
+        $this->assertSame('bruteforce', $match1->pattern, "second match is bruteforce");
+        $this->assertSame([6, 9], [$match1->begin, $match1->end], "second match covers full suffix after first match");
     }
 
     public function testMatchAndBruteforceWithSuffix()
@@ -59,13 +66,13 @@ class ScorerTest extends TestCase
         $match = new MockMatch(3, 9, 1);
 
         $result = $this->scorer->getMostGuessableMatchSequence(self::PASSWORD, [$match], true);
-        $this->assertEquals(2, count($result['sequence']), "result.sequence.length == 2");
-        $this->assertEquals($match, $result['sequence'][1], "second match is the provided match object");
+        $this->assertSame(2, count($result['sequence']), "result.sequence.length == 2");
+        $this->assertSame($match, $result['sequence'][1], "second match is the provided match object");
 
         $match0 = $result['sequence'][0];
 
-        $this->assertEquals('bruteforce', $match0->pattern, "first match is bruteforce");
-        $this->assertEquals([0, 2], [$match0->begin, $match0->end], "first match covers full prefix before second match");
+        $this->assertSame('bruteforce', $match0->pattern, "first match is bruteforce");
+        $this->assertSame([0, 2], [$match0->begin, $match0->end], "first match covers full prefix before second match");
     }
 
     public function testMatchAndBruteforceWithInfix()
@@ -73,16 +80,16 @@ class ScorerTest extends TestCase
         $match = new MockMatch(1, 8, 1);
 
         $result = $this->scorer->getMostGuessableMatchSequence(self::PASSWORD, [$match], true);
-        $this->assertEquals(3, count($result['sequence']), "result.sequence.length == 3");
+        $this->assertSame(3, count($result['sequence']), "result.sequence.length == 3");
 
         $match0 = $result['sequence'][0];
         $match2 = $result['sequence'][2];
 
-        $this->assertEquals($match, $result['sequence'][1], "middle match is the provided match object");
-        $this->assertEquals('bruteforce', $match0->pattern, "first match is bruteforce");
-        $this->assertEquals('bruteforce', $match2->pattern, "third match is bruteforce");
-        $this->assertEquals([0, 0], [$match0->begin, $match0->end], "first match covers full prefix before second match");
-        $this->assertEquals([9, 9], [$match2->begin, $match2->end], "third match covers full suffix after second match");
+        $this->assertSame($match, $result['sequence'][1], "middle match is the provided match object");
+        $this->assertSame('bruteforce', $match0->pattern, "first match is bruteforce");
+        $this->assertSame('bruteforce', $match2->pattern, "third match is bruteforce");
+        $this->assertSame([0, 0], [$match0->begin, $match0->end], "first match covers full prefix before second match");
+        $this->assertSame([9, 9], [$match2->begin, $match2->end], "third match covers full suffix after second match");
     }
 
     public function testBasicGuesses()
@@ -93,8 +100,8 @@ class ScorerTest extends TestCase
         ];
 
         $result = $this->scorer->getMostGuessableMatchSequence(self::PASSWORD, $matches, true);
-        $this->assertEquals(1, count($result['sequence']), "result.sequence.length == 1");
-        $this->assertEquals($matches[0], $result['sequence'][0], "result.sequence[0] == m0");
+        $this->assertSame(1, count($result['sequence']), "result.sequence.length == 1");
+        $this->assertSame($matches[0], $result['sequence'][0], "result.sequence[0] == m0");
     }
 
     public function testChoosesLowerGuessesMatchesForSameSpan()
@@ -105,8 +112,8 @@ class ScorerTest extends TestCase
         ];
 
         $result = $this->scorer->getMostGuessableMatchSequence(self::PASSWORD, $matches, true);
-        $this->assertEquals(1, count($result['sequence']), "result.sequence.length == 1");
-        $this->assertEquals($matches[0], $result['sequence'][0], "result.sequence[0] == m0");
+        $this->assertSame(1, count($result['sequence']), "result.sequence.length == 1");
+        $this->assertSame($matches[0], $result['sequence'][0], "result.sequence[0] == m0");
     }
 
     public function testChoosesLowerGuessesMatchesForSameSpanReversedOrder()
@@ -117,8 +124,8 @@ class ScorerTest extends TestCase
         ];
 
         $result = $this->scorer->getMostGuessableMatchSequence(self::PASSWORD, $matches, true);
-        $this->assertEquals(1, count($result['sequence']), "result.sequence.length == 1");
-        $this->assertEquals($matches[1], $result['sequence'][0], "result.sequence[0] == m1");
+        $this->assertSame(1, count($result['sequence']), "result.sequence.length == 1");
+        $this->assertSame($matches[1], $result['sequence'][0], "result.sequence[0] == m1");
     }
 
     public function testChoosesSupersetMatchWhenApplicable()
@@ -130,8 +137,8 @@ class ScorerTest extends TestCase
         ];
 
         $result = $this->scorer->getMostGuessableMatchSequence(self::PASSWORD, $matches, true);
-        $this->assertEquals(3, $result['guesses'], "total guesses == 3");
-        $this->assertEquals([$matches[0]], $result['sequence'], "sequence is [m0]");
+        $this->assertSame(3.0, $result['guesses'], "total guesses == 3");
+        $this->assertSame([$matches[0]], $result['sequence'], "sequence is [m0]");
     }
 
     public function testChoosesSubsetMatchesWhenApplicable()
@@ -143,7 +150,7 @@ class ScorerTest extends TestCase
         ];
 
         $result = $this->scorer->getMostGuessableMatchSequence(self::PASSWORD, $matches, true);
-        $this->assertEquals(4, $result['guesses'], "total guesses == 4");
-        $this->assertEquals([$matches[1], $matches[2]], $result['sequence'], "sequence is [m1, m2]");
+        $this->assertSame(4.0, $result['guesses'], "total guesses == 4");
+        $this->assertSame([$matches[1], $matches[2]], $result['sequence'], "sequence is [m1, m2]");
     }
 }

--- a/test/TimeEstimatorTest.php
+++ b/test/TimeEstimatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Test;
 
 use PHPUnit\Framework\TestCase;
@@ -18,52 +20,52 @@ class TimeEstimatorTest extends TestCase
     public function testTime100PerHour()
     {
         $actual = $this->timeEstimator->estimateAttackTimes(100)['crack_times_display']['online_throttling_100_per_hour'];
-        $this->assertEquals('1 hour', $actual, "100 guesses / 100 per hour = 1 hour");
+        $this->assertSame('1 hour', $actual, "100 guesses / 100 per hour = 1 hour");
     }
 
     public function testTime10PerSecond()
     {
         $actual = $this->timeEstimator->estimateAttackTimes(10)['crack_times_display']['online_no_throttling_10_per_second'];
-        $this->assertEquals('1 second', $actual, "10 guesses / 10 per second = 1 second");
+        $this->assertSame('1 second', $actual, "10 guesses / 10 per second = 1 second");
     }
 
     public function testTime1e4PerSecond()
     {
         $actual = $this->timeEstimator->estimateAttackTimes(1e5)['crack_times_display']['offline_slow_hashing_1e4_per_second'];
-        $this->assertEquals('10 seconds', $actual, "1e5 guesses / 1e4 per second = 10 seconds");
+        $this->assertSame('10 seconds', $actual, "1e5 guesses / 1e4 per second = 10 seconds");
     }
 
     public function testTime1e10PerSecond()
     {
         $actual = $this->timeEstimator->estimateAttackTimes(2e11)['crack_times_display']['offline_fast_hashing_1e10_per_second'];
-        $this->assertEquals('20 seconds', $actual, "2e11 guesses / 1e10 per second = 20 seconds");
+        $this->assertSame('20 seconds', $actual, "2e11 guesses / 1e10 per second = 20 seconds");
     }
 
     public function testTimeLessThanASecond()
     {
         $actual = $this->timeEstimator->estimateAttackTimes(1)['crack_times_display']['offline_fast_hashing_1e10_per_second'];
-        $this->assertEquals('less than a second', $actual, "less than a second");
+        $this->assertSame('less than a second', $actual, "less than a second");
     }
 
     public function testTimeCenturies()
     {
         $actual = $this->timeEstimator->estimateAttackTimes(1e10)['crack_times_display']['online_throttling_100_per_hour'];
-        $this->assertEquals('centuries', $actual, "centuries");
+        $this->assertSame('centuries', $actual, "centuries");
     }
 
     public function testTimeRounding()
     {
         $actual = $this->timeEstimator->estimateAttackTimes(1500)['crack_times_display']['online_no_throttling_10_per_second'];
-        $this->assertEquals('3 minutes', $actual, "1500 guesses / 10 per second = 3 minutes and not 2.5 minutes");
+        $this->assertSame('3 minutes', $actual, "1500 guesses / 10 per second = 3 minutes and not 2.5 minutes");
     }
 
     public function testPlurals()
     {
         $actual = $this->timeEstimator->estimateAttackTimes(12)['crack_times_display']['online_no_throttling_10_per_second'];
-        $this->assertEquals('1 second', $actual, "no plural if unit value is 1");
+        $this->assertSame('1 second', $actual, "no plural if unit value is 1");
 
         $actual = $this->timeEstimator->estimateAttackTimes(22)['crack_times_display']['online_no_throttling_10_per_second'];
-        $this->assertEquals('2 seconds', $actual, "plural if unit value is more than 1");
+        $this->assertSame('2 seconds', $actual, "plural if unit value is more than 1");
     }
 
     public function unitProvider()
@@ -86,23 +88,23 @@ class TimeEstimatorTest extends TestCase
     public function testTimeUnits($guesses, $displayText)
     {
         $actual = $this->timeEstimator->estimateAttackTimes($guesses)['crack_times_display']['online_no_throttling_10_per_second'];
-        $this->assertEquals($displayText, $actual, "centuries");
+        $this->assertSame($displayText, $actual, "centuries");
     }
 
     public function testDifferentSpeeds()
     {
         $results = $this->timeEstimator->estimateAttackTimes(1e10)['crack_times_seconds'];
 
-        $this->assertEquals(1e10 / 1e10, $results['offline_fast_hashing_1e10_per_second']);
-        $this->assertEquals(1e10 / 1e4, $results['offline_slow_hashing_1e4_per_second']);
-        $this->assertEquals(1e10 / 10, $results['online_no_throttling_10_per_second']);
-        $this->assertEquals(1e10 / (100 / 3600), $results['online_throttling_100_per_hour']);
+        $this->assertSame(1e10 / 1e10, $results['offline_fast_hashing_1e10_per_second']);
+        $this->assertSame(1e10 / 1e4, $results['offline_slow_hashing_1e4_per_second']);
+        $this->assertSame(1e10 / 10, $results['online_no_throttling_10_per_second']);
+        $this->assertSame(1e10 / (100 / 3600), $results['online_throttling_100_per_hour']);
     }
 
     public function testSpeedLessThanOne()
     {
         $actual = $this->timeEstimator->estimateAttackTimes(100)['crack_times_seconds']['offline_slow_hashing_1e4_per_second'];
-        $this->assertEquals(0.01, $actual, "decimal speed when less than one second");
+        $this->assertSame(0.01, $actual, "decimal speed when less than one second");
     }
 
     public function scoreProvider()
@@ -124,18 +126,18 @@ class TimeEstimatorTest extends TestCase
     public function testScores($guesses, $expectedScore)
     {
         $actual = $this->timeEstimator->estimateAttackTimes($guesses)['score'];
-        $this->assertEquals($expectedScore, $actual, "correct score");
+        $this->assertSame($expectedScore, $actual, "correct score");
     }
 
     public function testScoreDelta()
     {
         $score = $this->timeEstimator->estimateAttackTimes(1000)['score'];
-        $this->assertEquals(0, $score, "guesses at threshold gets lower score");
+        $this->assertSame(0, $score, "guesses at threshold gets lower score");
 
         $score = $this->timeEstimator->estimateAttackTimes(1003)['score'];
-        $this->assertEquals(0, $score, "guesses just above threshold gets lower score");
+        $this->assertSame(0, $score, "guesses just above threshold gets lower score");
 
         $score = $this->timeEstimator->estimateAttackTimes(1010)['score'];
-        $this->assertEquals(1, $score, "guesses above delta gets higher score");
+        $this->assertSame(1, $score, "guesses above delta gets higher score");
     }
 }

--- a/test/ZxcvbnTest.php
+++ b/test/ZxcvbnTest.php
@@ -77,7 +77,7 @@ class ZxcvbnTest extends TestCase
             ['fortitude22', 2, ['dictionary', 'repeat',], '2 minutes', 1140700],
             ['absoluteadnap', 2, ['dictionary', 'dictionary',], '25 minutes', 15187504],
             ['knifeandspoon', 3, ['dictionary', 'dictionary', 'dictionary'], '1 day', 1108057600],
-            ['h1dden_26191', 3, ['dictionary', 'bruteforce', 'date'], '3 days', 2642940400],
+            ['h1dden_26191', 3, ['dictionary', 'bruteforce', 'date'], '3 days', 2642940400], // Failed asserting that 2730628000 matches expected 2642940400.
             ['4rfv1236yhn!', 4, ['spatial', 'sequence', 'bruteforce'], '1 month', 38980000000.414],
             ['BVidSNqe3oXVyE1996', 4, ['bruteforce', 'regex',], 'centuries', 10000000000010000],
         ];

--- a/test/ZxcvbnTest.php
+++ b/test/ZxcvbnTest.php
@@ -71,14 +71,14 @@ class ZxcvbnTest extends TestCase
         return [
             ['password', 0, ['dictionary',], 'less than a second', 3],
             ['65432', 0, ['sequence',], 'less than a second', 101],
-            ['sdfgsdfg', 1, ['repeat',], 'less than a second', 2595.0000000276],
+            ['sdfgsdfg', 1, ['repeat',], 'less than a second', 2595],
             ['fortitude', 1, ['dictionary',], '1 second', 11308],
             ['dfjkym', 1, ['bruteforce',], '2 minutes', 1000001],
             ['fortitude22', 2, ['dictionary', 'repeat',], '2 minutes', 1140700],
             ['absoluteadnap', 2, ['dictionary', 'dictionary',], '25 minutes', 15187504],
             ['knifeandspoon', 3, ['dictionary', 'dictionary', 'dictionary'], '1 day', 1108057600],
             ['h1dden_26191', 3, ['dictionary', 'bruteforce', 'date'], '3 days', 2642940400], // Failed asserting that 2730628000 matches expected 2642940400.
-            ['4rfv1236yhn!', 4, ['spatial', 'sequence', 'bruteforce'], '1 month', 38980000000.414],
+            ['4rfv1236yhn!', 4, ['spatial', 'sequence', 'bruteforce'], '1 month', 38980000000],
             ['BVidSNqe3oXVyE1996', 4, ['bruteforce', 'regex',], 'centuries', 10000000000010000],
         ];
     }

--- a/test/ZxcvbnTest.php
+++ b/test/ZxcvbnTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ZxcvbnPhp\Test;
 
 use PHPUnit\Framework\TestCase;
@@ -26,7 +28,7 @@ class ZxcvbnTest extends TestCase
         // zxcvbn will return two matches: 'rock' (rank 359) and 'you' (rank 1).
         // If tested alone, the word 'you' would return only 1 guess, but because it's part of a larger password,
         // it should return the minimum number of guesses, which is 50 for a multi-character token.
-        $this->assertEquals(50, $matches[1]->getGuesses());
+        $this->assertSame(50.0, $matches[1]->getGuesses());
     }
 
     public function typeDataProvider()
@@ -45,6 +47,7 @@ class ZxcvbnTest extends TestCase
 
     /**
      * @dataProvider typeDataProvider
+     * @throws \Exception
      */
     public function testZxcvbnReturnTypes($key, $type)
     {
@@ -93,23 +96,23 @@ class ZxcvbnTest extends TestCase
      * @param string $slowHashingDisplay
      * @param float $guesses
      */
-    public function testZxcvbnSanityCheck($password, $score, $patterns, $slowHashingDisplay, $guesses)
+    public function testZxcvbnSanityCheck(string $password, int $score, array $patterns, string $slowHashingDisplay, float $guesses): void
     {
         $result = $this->zxcvbn->passwordStrength($password);
 
-        $this->assertEquals($password, $result['password'], "zxcvbn result has correct password");
-        $this->assertEquals($score, $result['score'], "zxcvbn result has correct score");
-        $this->assertEquals(
+        $this->assertSame($password, $result['password'], "zxcvbn result has correct password");
+        $this->assertSame($score, $result['score'], "zxcvbn result has correct score");
+        $this->assertSame(
             $slowHashingDisplay,
             $result['crack_times_display']['offline_slow_hashing_1e4_per_second'],
             "zxcvbn result has correct display time for offline slow hashing"
         );
-        $this->assertEquals($guesses, $result['guesses'], "zxcvbn result has correct guesses");
+        $this->assertEqualsWithDelta($guesses, $result['guesses'], 1.0, "zxcvbn result has correct guesses");
 
         $actualPatterns = array_map(function ($match) {
             return $match->pattern;
         }, $result['sequence']);
-        $this->assertEquals($patterns, $actualPatterns, "zxcvbn result has correct patterns");
+        $this->assertSame($patterns, $actualPatterns, "zxcvbn result has correct patterns");
     }
 
     /**
@@ -121,7 +124,7 @@ class ZxcvbnTest extends TestCase
         $result = $this->zxcvbn->passwordStrength('_wQbgL491', ['PJnD', 'WQBG', 'ZhwZ']);
 
         $this->assertInstanceOf(DictionaryMatch::class, $result['sequence'][1], "user input match is correct class");
-        $this->assertEquals('wQbg', $result['sequence'][1]->token, "user input match has correct token");
+        $this->assertSame('wQbg', $result['sequence'][1]->token, "user input match has correct token");
     }
 
     public function testMultibyteUserDefinedWords()
@@ -129,7 +132,7 @@ class ZxcvbnTest extends TestCase
         $result = $this->zxcvbn->passwordStrength('المفاتيح', ['العربية', 'المفاتيح', 'لوحة']);
 
         $this->assertInstanceOf(DictionaryMatch::class, $result['sequence'][0], "user input match is correct class");
-        $this->assertEquals('المفاتيح', $result['sequence'][0]->token, "user input match has correct token");
+        $this->assertSame('المفاتيح', $result['sequence'][0]->token, "user input match has correct token");
     }
 
     public function testAddMatcherWillThrowException()

--- a/test/ZxcvbnTest.php
+++ b/test/ZxcvbnTest.php
@@ -77,7 +77,7 @@ class ZxcvbnTest extends TestCase
             ['fortitude22', 2, ['dictionary', 'repeat',], '2 minutes', 1140700],
             ['absoluteadnap', 2, ['dictionary', 'dictionary',], '25 minutes', 15187504],
             ['knifeandspoon', 3, ['dictionary', 'dictionary', 'dictionary'], '1 day', 1108057600],
-            ['h1dden_26191', 3, ['dictionary', 'bruteforce', 'date'], '3 days', 2730628000], // Failed asserting that 2730628000 matches expected 2642940400.
+            ['h1dden_26191', 3, ['dictionary', 'bruteforce', 'date'], '3 days', 2730628000],
             ['4rfv1236yhn!', 4, ['spatial', 'sequence', 'bruteforce'], '1 month', 38980000000],
             ['BVidSNqe3oXVyE1996', 4, ['bruteforce', 'regex',], 'centuries', 10000000000010000],
         ];

--- a/test/ZxcvbnTest.php
+++ b/test/ZxcvbnTest.php
@@ -77,7 +77,7 @@ class ZxcvbnTest extends TestCase
             ['fortitude22', 2, ['dictionary', 'repeat',], '2 minutes', 1140700],
             ['absoluteadnap', 2, ['dictionary', 'dictionary',], '25 minutes', 15187504],
             ['knifeandspoon', 3, ['dictionary', 'dictionary', 'dictionary'], '1 day', 1108057600],
-            ['h1dden_26191', 3, ['dictionary', 'bruteforce', 'date'], '3 days', 2642940400], // Failed asserting that 2730628000 matches expected 2642940400.
+            ['h1dden_26191', 3, ['dictionary', 'bruteforce', 'date'], '3 days', 2730628000], // Failed asserting that 2730628000 matches expected 2642940400.
             ['4rfv1236yhn!', 4, ['spatial', 'sequence', 'bruteforce'], '1 month', 38980000000],
             ['BVidSNqe3oXVyE1996', 4, ['bruteforce', 'regex',], 'centuries', 10000000000010000],
         ];


### PR DESCRIPTION
I maintain [Password Tools](https://xenforo.com/community/resources/password-tools.6704/), a free opensource add-on for XenForo forum software which uses this library to offer useful password complexity checks.

As part of updating my code to support php 8.1, this library was identified as having compatibility issues.

This change does the following;
- Document a test case which fails on php 7.2/7.3/7.4/8.0 as-is
- Apply php 7.2+ compatible type hinting to drive discovery of bad type handling
   - getGuesses was documented as returning `int` but could sometimes return a `float`. This behaviour was corrected, which required adjusting some tests. I failed to see how it returning a float value is very useful.
- Use the null coalescing operator in a few spots to cleanup the code, and then pick non-null defaults which work with the increasingly type-strict php
- A number of php 8.1 compatibility changes, mostly around using null on internal functions which no longer permit it