### PR TITLE
Fix type error

### DIFF
--- a/src/Scorer.php
+++ b/src/Scorer.php
@@ -258,9 +258,9 @@ class Scorer
     /**
      * unoptimized, called only on small n
      * @param int $n
-     * @return int
+     * @return int|float
      */
-    protected function factorial(int $n): int
+    protected function factorial(int $n)
     {
         if ($n < 2) {
             return 1;


### PR DESCRIPTION
This fix ` Uncaught TypeError: factorial(): Return value must be of type int, float returned`. If the `$n`parameter in `factorial()` is bigger than 20, it will cause type error because PHP converts int to float.

Demonstration: https://onlinephp.io/c/3bbad