### PR TITLE
Declare factorial as returning a float in order to fix issue 74

### DIFF
--- a/src/Scorer.php
+++ b/src/Scorer.php
@@ -260,7 +260,7 @@ class Scorer
      * @param int $n
      * @return int
      */
-    protected function factorial(int $n): int
+    protected function factorial(int $n): float
     {
         if ($n < 2) {
             return 1;


### PR DESCRIPTION
It works perfectly fine to have the factorial function in Scorer.php to be declared as returning a float.
This results in the same output as before, and extends the code to work with longer strings.
It is valid because the value of `$pi` is a float and it will cause the value of `$g` to become a float no matter if factorial returns an int or a float. I hope I am not being too lazy or naive here.

Note that if you use really really huge passwords you can exceed runtime limits, but that is another issue, out of scope here.
You can experiment with `ulimit -t 300` if you wish.

Proposed fix for https://github.com/bjeavons/zxcvbn-php/issues/74
