### PR TITLE
php 8.4 compatibility

### DIFF
--- a/src/Matchers/ReverseDictionaryMatch.php
+++ b/src/Matchers/ReverseDictionaryMatch.php
@@ -54,7 +54,7 @@ class ReverseDictionaryMatch extends DictionaryMatch
         return $feedback;
     }
 
-    public static function mbStrRev(string $string, string $encoding = null): string
+    public static function mbStrRev(string $string, ?string $encoding = null): string
     {
         if ($encoding === null) {
             $encoding = mb_detect_encoding($string) ?: 'UTF-8';


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

Implicit nulls are deprecated from php 8.4+, thankfully the fix is compatible with php 7.1+